### PR TITLE
some Dirtranslator cleanup

### DIFF
--- a/ce_main_app/translated/dirtranslator.cpp
+++ b/ce_main_app/translated/dirtranslator.cpp
@@ -14,6 +14,10 @@
 #include "dirtranslator.h"
 #include "gemdos.h"
 
+#define GEMDOS_FILE_MAXSIZE	(2147483647)
+// TOS 1.x cannot display size with more than 8 digits
+//#define GEMDOS_FILE_MAXSIZE (100*1000*1000-1)
+
 DirTranslator::DirTranslator()
 {
     fsDirs.count    = 0;
@@ -357,10 +361,16 @@ void DirTranslator::appendFoundToFindStorage(std::string &hostPath, const char *
     buf[4] = atariDate &  0xff;
 
     // File Length
-    buf[5] = attr.st_size >>  24;
-    buf[6] = attr.st_size >>  16;
-    buf[7] = attr.st_size >>   8;
-    buf[8] = attr.st_size & 0xff;
+	DWORD size;
+	if(attr.st_size > GEMDOS_FILE_MAXSIZE) {
+		size = GEMDOS_FILE_MAXSIZE;
+	} else {
+		size = (DWORD)attr.st_size;
+	}
+    buf[5] = (size >>  24) & 0xff;
+    buf[6] = (size >>  16) & 0xff;
+    buf[7] = (size >>   8) & 0xff;
+    buf[8] = size & 0xff;
 
     // Filename -- d_fname[14]
     memset(&buf[9], 0, 14);                                // first clear the mem

--- a/ce_main_app/translated/dirtranslator.cpp
+++ b/ce_main_app/translated/dirtranslator.cpp
@@ -83,11 +83,11 @@ void DirTranslator::shortToLongPath(std::string &rootPath, std::string &shortPat
 
         FilenameShortener *fs;
         if(it != mapPathToShortener.end()) {            // already got the shortener
-            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortener for pathPart: %s found", (char *) pathPart.c_str());
+            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortener for pathPart: %s found", pathPart.c_str());
         
             fs = it->second;
         } else {                                        // don't have the shortener yet
-            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortener for pathPart: %s NOT found, will create shortener", (char *) pathPart.c_str());
+            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortener for pathPart: %s NOT found, will create shortener", pathPart.c_str());
 
             fs = createShortener(pathPart);
         }
@@ -96,12 +96,12 @@ void DirTranslator::shortToLongPath(std::string &rootPath, std::string &shortPat
             continue;
         }
         
-        res = fs->shortToLongFileName((char *) strings[i].c_str(), longName);   // try to convert the name
+        res = fs->shortToLongFileName(strings[i].c_str(), longName);   // try to convert the name
 
         if(res) {                                       // if there was a long version of the file name, replace the short one
             strings[i] = longName;
         } else {
-            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortToLongFileName() failed for short name: %s", (char *) strings[i].c_str());
+            Debug::out(LOG_DEBUG, "DirTranslator::shortToLongPath - shortToLongFileName() failed for short name: %s", strings[i].c_str());
         }
 
         Utils::mergeHostPaths(pathPart, strings[i]);   // build the path slowly
@@ -126,17 +126,17 @@ bool DirTranslator::longToShortFilename(std::string &longHostPath, std::string &
 
     FilenameShortener *fs;
     if(it != mapPathToShortener.end()) {            // already got the shortener
-        Debug::out(LOG_DEBUG, "DirTranslator::longToShortFilename - shortener for longHostPath: %s found", (char *) longHostPath.c_str());
+        Debug::out(LOG_DEBUG, "DirTranslator::longToShortFilename - shortener for longHostPath: %s found", longHostPath.c_str());
 
         fs = it->second;
     } else {                                        // don't have the shortener yet
-        Debug::out(LOG_DEBUG, "DirTranslator::longToShortFilename - shortener for longHostPath: %s NOT found, will create shortener", (char *) longHostPath.c_str());
+        Debug::out(LOG_DEBUG, "DirTranslator::longToShortFilename - shortener for longHostPath: %s NOT found, will create shortener", longHostPath.c_str());
 
         fs = createShortener(longHostPath);
     }
 
     char shortName[32];                             // try to shorten the name
-    bool res = fs->longToShortFileName((char *) longFname.c_str(), shortName);   // try to convert the name from long to short
+    bool res = fs->longToShortFileName(longFname.c_str(), shortName);   // try to convert the name from long to short
 
     if(res) {                                       // name shortened - store it
         shortFname = shortName;
@@ -152,7 +152,7 @@ FilenameShortener *DirTranslator::createShortener(std::string &path)
     FilenameShortener *fs = new FilenameShortener();
     mapPathToShortener.insert( std::pair<std::string, FilenameShortener *>(path, fs) );
 
-	DIR *dir = opendir((char *) path.c_str());						// try to open the dir
+	DIR *dir = opendir(path.c_str());						// try to open the dir
 	
     if(dir == NULL) {                                 				// not found?
         return fs;
@@ -220,7 +220,7 @@ bool DirTranslator::buildGemdosFindstorageData(TFindStorage *fs, std::string hos
 			if((isRootDir)||((findAttribs&FA_DIR)==0)) {    // for root dir or when no subdirs are requested (FA_DIR) - don't add '.' or '..'
                 continue;
             } else {                                        // for non-root dir                                       - must add '.' or '..' (TOS does this, and it makes the TOS dir copying work)
-                appendFoundToFindStorage_dirUpDirCurr(hostPath, (char *) searchString.c_str(), fs, de, findAttribs);
+                appendFoundToFindStorage_dirUpDirCurr(hostPath, searchString.c_str(), fs, de, findAttribs);
                 continue;
             }            
 		}	
@@ -231,13 +231,13 @@ bool DirTranslator::buildGemdosFindstorageData(TFindStorage *fs, std::string hos
                 int len = strlen(de->d_name);                                   // get filename length
                 
                 if(len > 4) {                                                   // if filename is at least 5 chars long
-                    char *found = strcasestr(de->d_name + len - 4, (char *) ".ZIP");    // see if it ends with .ZIP
+                    char *found = strcasestr(de->d_name + len - 4, ".ZIP");    // see if it ends with .ZIP
 
                     if(found != NULL) {                                         // if filename ends with .ZIP
                         std::string fullZipPath = hostPath + "/" + longFname;   // create full path to that zip file
                     
                         struct stat attr;
-                        int res = stat((char *) fullZipPath.c_str(), &attr);    // get the status of the possible zip file
+                        int res = stat(fullZipPath.c_str(), &attr);    // get the status of the possible zip file
 
                         if(res == 0) {                                          // if stat() succeeded
                             if(attr.st_size <= MAX_ZIPDIR_ZIPFILE_SIZE) {       // file not too big? change flags from file to dir
@@ -250,7 +250,7 @@ bool DirTranslator::buildGemdosFindstorageData(TFindStorage *fs, std::string hos
         }
         
 		// finnaly append to the find storage
-		appendFoundToFindStorage(hostPath, (char *) searchString.c_str(), fs, de, findAttribs);
+		appendFoundToFindStorage(hostPath, searchString.c_str(), fs, de, findAttribs);
 
         if(fs->count >= fs->maxCount) {         					// avoid buffer overflow
             break;
@@ -269,7 +269,7 @@ bool DirTranslator::buildGemdosFindstorageData(TFindStorage *fs, std::string hos
 	return true;
 }
 
-void DirTranslator::appendFoundToFindStorage(std::string &hostPath, char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs)
+void DirTranslator::appendFoundToFindStorage(std::string &hostPath, const char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs)
 {
     // TODO: verify on ST that the find attributes work like this
 
@@ -336,10 +336,10 @@ void DirTranslator::appendFoundToFindStorage(std::string &hostPath, char *search
 
     // now convert the short 'FILE.C' to 'FILE    .C  '
     char shortFnameExtended[14];
-    FilenameShortener::extendWithSpaces((char *) shortFname.c_str(), shortFnameExtended);
+    FilenameShortener::extendWithSpaces(shortFname.c_str(), shortFnameExtended);
 
     // check the current name against searchString using fnmatch
-	int ires = compareSearchStringAndFilename(searchString, (char *) shortFname.c_str());
+	int ires = compareSearchStringAndFilename(searchString, shortFname.c_str());
 		
 	if(ires != 0) {     // not matching? quit
 		return;
@@ -363,15 +363,15 @@ void DirTranslator::appendFoundToFindStorage(std::string &hostPath, char *search
     buf[8] = attr.st_size & 0xff;
 
     // Filename -- d_fname[14]
-    memset(&buf[9], 0, 14);                                         // first clear the mem
-//  strncpy((char *) &buf[9], (char *) shortFnameExtended, 14);     // copy the filename - 'FILE    .C  '
-    strncpy((char *) &buf[9], (char *) shortFname.c_str(), 14);     // copy the filename - 'FILE.C'
+    memset(&buf[9], 0, 14);                                // first clear the mem
+//  strncpy((char *) &buf[9], shortFnameExtended, 14);     // copy the filename - 'FILE    .C  '
+    strncpy((char *) &buf[9], shortFname.c_str(), 14);     // copy the filename - 'FILE.C'
 
     fsPart->count++;                                                // increase partial count
     fs->count++;                                                    // increase total count
 }
 
-void DirTranslator::appendFoundToFindStorage_dirUpDirCurr(std::string &hostPath, char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs)
+void DirTranslator::appendFoundToFindStorage_dirUpDirCurr(std::string &hostPath, const char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs)
 {
     TFindStorage *fsPart = &fsDirs;                     // get the pointer to partial find storage to separate dirs from files when searching
 
@@ -404,7 +404,7 @@ void DirTranslator::appendFoundToFindStorage_dirUpDirCurr(std::string &hostPath,
     WORD atariDate = Utils::fileTimeToAtariDate(timestr);
 
     // check the current name against searchString using fnmatch
-	int ires = compareSearchStringAndFilename(searchString, (char *) shortFname.c_str());
+	int ires = compareSearchStringAndFilename(searchString, shortFname.c_str());
 		
 	if(ires != 0) {     // not matching? quit
 		return;
@@ -445,7 +445,7 @@ void DirTranslator::toUpperCaseString(std::string &st)
 	}
 }
 
-int DirTranslator::compareSearchStringAndFilename(char *searchString, char *filename)
+int DirTranslator::compareSearchStringAndFilename(const char *searchString, const char *filename)
 {
 	char ss1[16], ss2[16];
 	char fn1[16], fn2[16];

--- a/ce_main_app/translated/dirtranslator.h
+++ b/ce_main_app/translated/dirtranslator.h
@@ -51,10 +51,10 @@ private:
     FilenameShortener *createShortener(std::string &path);
     void splitFilenameFromPath(std::string &pathAndFile, std::string &path, std::string &file);
 
-    void appendFoundToFindStorage(std::string &hostPath, char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs);
-	void appendFoundToFindStorage_dirUpDirCurr(std::string &hostPath, char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs);
+    void appendFoundToFindStorage(std::string &hostPath, const char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs);
+	void appendFoundToFindStorage_dirUpDirCurr(std::string &hostPath, const char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs);
 
-	int compareSearchStringAndFilename(char *searchString, char *filename);
+	int compareSearchStringAndFilename(const char *searchString, const char *filename);
 	void toUpperCaseString(std::string &st);
 };
 

--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -126,7 +126,7 @@ void FilenameShortener::removeSpaceExtension(const char *extendedFn, char *extRe
     removeTrailingSpaces(fname);                            // convert 'FILE    ' to 'FILE'
     removeTrailingSpaces(ext);                              // convert 'C  ' to 'C'
 
-    mergeFilenameAndExtension(fname, ext, false, extendedFn);
+    mergeFilenameAndExtension(fname, ext, false, extRemovedFn);
 }
 
 void FilenameShortener::extendWithSpaces(const char *normalFname, char *extendedFn)

--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -15,7 +15,7 @@ void FilenameShortener::clear(void)
     mapFilenameNoExt.clear();
 }
 
-bool FilenameShortener::longToShortFileName(char *longFileName, char *shortFileName)
+bool FilenameShortener::longToShortFileName(const char *longFileName, char *shortFileName)
  {
      // QStringList &fileNames, QStringList &fullNames
     static char fileName[MAX_FILENAME_LEN];
@@ -29,7 +29,7 @@ bool FilenameShortener::longToShortFileName(char *longFileName, char *shortFileN
     it = mapFilenameWithExt.find(longFileName);                  // try to find the string in the map
 
     if(it != mapFilenameWithExt.end()) {                        // if we have this fileName already, use it!
-        char *shortFileNameFromMap = (char *) it->second.c_str();
+        const char *shortFileNameFromMap = it->second.c_str();
         strcpy(shortFileName, shortFileNameFromMap);
         return true;
     }
@@ -90,7 +90,7 @@ bool FilenameShortener::longToShortFileName(char *longFileName, char *shortFileN
     return true;
 }
 
-void FilenameShortener::mergeFilenameAndExtension(char *shortFn, char *shortExt, bool extendWithSpaces, char *merged)
+void FilenameShortener::mergeFilenameAndExtension(const char *shortFn, const char *shortExt, bool extendWithSpaces, char *merged)
 {
     if(extendWithSpaces) {                                      // space extended - 'FILE    .C  '
         memset(merged, ' ', 12);                                // clear the
@@ -103,8 +103,8 @@ void FilenameShortener::mergeFilenameAndExtension(char *shortFn, char *shortExt,
         lenFn = MIN(lenFn, 8);
         lenEx = MIN(lenEx, 3);
 
-        strncpy(merged,     shortFn,    lenFn);                 // copy in the filename
-        strncpy(merged + 9, shortExt,   lenEx);                 // copy in the file extension
+        memcpy(merged,     shortFn,    lenFn);                 // copy in the filename
+        memcpy(merged + 9, shortExt,   lenEx);                 // copy in the file extension
     } else {                                                    // not extended - 'FILE.C'
         memset(merged, 0, 13);                                  // clear the final string first
 
@@ -117,7 +117,7 @@ void FilenameShortener::mergeFilenameAndExtension(char *shortFn, char *shortExt,
     }
 }
 
-void FilenameShortener::removeSpaceExtension(char *extendedFn, char *extRemovedFn)
+void FilenameShortener::removeSpaceExtension(const char *extendedFn, char *extRemovedFn)
 {
     char fname[12];
     char ext[4];
@@ -129,7 +129,7 @@ void FilenameShortener::removeSpaceExtension(char *extendedFn, char *extRemovedF
     mergeFilenameAndExtension(fname, ext, false, extendedFn);
 }
 
-void FilenameShortener::extendWithSpaces(char *normalFname, char *extendedFn)
+void FilenameShortener::extendWithSpaces(const char *normalFname, char *extendedFn)
 {
     char fname[12];
     char ext[4];
@@ -152,7 +152,7 @@ void FilenameShortener::removeTrailingSpaces(char *str)
     }
 }
 
-bool FilenameShortener::shortToLongFileName(char *shortFileName, char *longFileName)
+bool FilenameShortener::shortToLongFileName(const char *shortFileName, char *longFileName)
 {
     if(strlen(shortFileName) == 0) {                            // empty short path? fail
         return false;
@@ -170,7 +170,7 @@ bool FilenameShortener::shortToLongFileName(char *shortFileName, char *longFileN
     return false;
 }
 
-int FilenameShortener::strCharPos(char *str, int maxLen, char ch)
+int FilenameShortener::strCharPos(const char *str, int maxLen, char ch)
 {
     int i;
 
@@ -187,7 +187,7 @@ int FilenameShortener::strCharPos(char *str, int maxLen, char ch)
     return -1;                      // not found
 }
 
-void FilenameShortener::splitFilenameFromExtension(char *filenameWithExt, char *fileName, char *ext)
+void FilenameShortener::splitFilenameFromExtension(const char *filenameWithExt, char *fileName, char *ext)
 {
     int filenameLength = strlen(filenameWithExt);
 
@@ -306,8 +306,7 @@ void FilenameShortener::replaceNonLetters(char *str)
     int i, len, j;
     len = strlen(str);
 
-    char *allowed = (char *) "!#$%&'()~^@-_{}";
-    #define ALLOWED_COUNT   15
+    const char *allowed = "!#$%&'()~^@-_{}";
 
     for(i=0; i<len; i++) {
         if(str[i] >= '0' && str[i] <= '9') {    // numbers are OK
@@ -324,7 +323,7 @@ void FilenameShortener::replaceNonLetters(char *str)
         }
 
         bool isAllowed = false;
-        for(j=0; j<ALLOWED_COUNT; j++) {        // try to find this char in allowed characters array
+        for(j=0; allowed[j] != '\0'; j++) {        // try to find this char in allowed characters array
             if(str[i] == allowed[j]) {
                 isAllowed = true;
                 break;

--- a/ce_main_app/translated/filenameshortener.h
+++ b/ce_main_app/translated/filenameshortener.h
@@ -24,14 +24,14 @@ public:
 
     void clear(void);                                                       // clear maps - e.g. on ST restart
 
-    bool longToShortFileName(char *longFileName, char *shortFileName);      // translates 'long file name' to 'long_f~1'
-    bool shortToLongFileName(char *shortFileName, char *longFileName);      // translates 'long_f~1' to 'long file name'
+    bool longToShortFileName(const char *longFileName, char *shortFileName);      // translates 'long file name' to 'long_f~1'
+    bool shortToLongFileName(const char *shortFileName, char *longFileName);      // translates 'long_f~1' to 'long file name'
 
-    static void mergeFilenameAndExtension(char *shortFn, char *shortExt, bool extendWithSpaces, char *merged);
+    static void mergeFilenameAndExtension(const char *shortFn, const char *shortExt, bool extendWithSpaces, char *merged);
 
-    static void removeSpaceExtension(char *extendedFn, char *extRemovedFn); // 'FILE    .C  ' -> 'FILE.C'
-    static void extendWithSpaces(char *normalFname, char *extendedFn);      // 'FILE.C'       -> 'FILE    .C  '
-    static void splitFilenameFromExtension(char *filenameWithExt, char *fileName, char *ext);
+    static void removeSpaceExtension(const char *extendedFn, char *extRemovedFn); // 'FILE    .C  ' -> 'FILE.C'
+    static void extendWithSpaces(const char *normalFname, char *extendedFn);      // 'FILE.C'       -> 'FILE    .C  '
+    static void splitFilenameFromExtension(const char *filenameWithExt, char *fileName, char *ext);
 
 private:
     std::map<std::string, std::string>  mapFilenameWithExt;                 // for file name conversion from long to short
@@ -42,7 +42,7 @@ private:
     bool shortenName(char *nLong, char *nShort);
     bool shortenExtension(char *shortFileName, char *nLongExt, char *nShortExt);
 
-    static int  strCharPos(char *str, int maxLen, char ch);
+    static int  strCharPos(const char *str, int maxLen, char ch);
     static void replaceNonLetters(char *str);
     static void extendToLenghtWithSpaces(char *str, int len);
     static void removeTrailingSpaces(char *str);


### PR DESCRIPTION
I was trying to understand how a GEM bug happen (1.x)
So I cleaned all the (char *) casting in dirtranslator.cpp and filenameshortener.cpp
So I found a bug in FilenameShortener::removeSpaceExtension()
and finally I implemented a limit on filesize returned (GEMTOS file sizes are signed 32bit int's, right ?)
