### PR TITLE
Improve Path shortener

### DIFF
--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -1,3 +1,4 @@
+// vim: shiftwidth=4 softtabstop=4 tabstop=4 expandtab
 #include <stdio.h>
 #include <string.h>
 
@@ -218,8 +219,8 @@ void FilenameShortener::splitFilenameFromExtension(const char *filenameWithExt, 
     }
 }
 
- bool FilenameShortener::shortenName(char *nLong, char *nShort)
- {
+bool FilenameShortener::shortenName(const char *nLong, char *nShort)
+{
     int ind = 1;
     char num[12], newName[12];
     std::map<std::string, std::string>::iterator it;
@@ -250,7 +251,7 @@ void FilenameShortener::splitFilenameFromExtension(const char *filenameWithExt, 
     return false;                                          // failed
 }
 
-bool FilenameShortener::shortenExtension(char *shortFileName, char *nLongExt, char *nShortExt)
+bool FilenameShortener::shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt)
 {
      int ind = 1;
 
@@ -350,5 +351,3 @@ void FilenameShortener::extendToLenghtWithSpaces(char *str, int len)
 
     str[len] = 0;                   // terminate with zero
 }
-
-

--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -177,15 +177,11 @@ bool FilenameShortener::shortToLongFileName(const char *shortFileName, char *lon
     return false;
 }
 
-int FilenameShortener::strCharPos(const char *str, int maxLen, char ch)
+int FilenameShortener::strrCharPos(const char *str, int maxLen, char ch)
 {
     int i;
 
-    for(i=0; i<maxLen; i++) {       // find that char!
-        if(str[i] == 0) {           // end of string?
-            break;
-        }
-
+    for(i = MIN((int)strlen(str), maxLen) - 1; i >= 0; i--) {       // find that char!
         if(str[i] == ch) {          // that character found?
             return i;
         }
@@ -207,7 +203,7 @@ void FilenameShortener::splitFilenameFromExtension(const char *filenameWithExt, 
     memset(ext, 0, 4);
 
     // divide longFileName to filename and extension
-    int dotPos = strCharPos(filenameWithExt, filenameLength, '.'); // find name and extension separator
+    int dotPos = strrCharPos(filenameWithExt, filenameLength, '.'); // find name and extension separator
 
     if(dotPos == -1) {                                          // not found?
         strncpy(fileName, filenameWithExt, filenameLength + 1); // copy whole name to filename

--- a/ce_main_app/translated/filenameshortener.h
+++ b/ce_main_app/translated/filenameshortener.h
@@ -38,9 +38,11 @@ private:
     std::map<std::string, std::string>  mapReverseFilename;                 // for file name conversion from short to long
 
     std::map<std::string, std::string> mapFilenameNoExt;                    // used by shortenName() to create unique file name with ~
+    bool allowExtUse;          // Allow use of Extension for shortening (if file without extension)
 
     bool shortenName(const char *nLong, char *nShort);
     bool shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt);
+    bool shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt);
 
     static int  strCharPos(const char *str, int maxLen, char ch);
     static void replaceNonLetters(char *str);

--- a/ce_main_app/translated/filenameshortener.h
+++ b/ce_main_app/translated/filenameshortener.h
@@ -44,7 +44,7 @@ private:
     bool shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt);
     bool shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt);
 
-    static int  strCharPos(const char *str, int maxLen, char ch);
+    static int  strrCharPos(const char *str, int maxLen, char ch);
     static void replaceNonLetters(char *str);
     static void extendToLenghtWithSpaces(char *str, int len);
     static void removeTrailingSpaces(char *str);

--- a/ce_main_app/translated/filenameshortener.h
+++ b/ce_main_app/translated/filenameshortener.h
@@ -39,8 +39,8 @@ private:
 
     std::map<std::string, std::string> mapFilenameNoExt;                    // used by shortenName() to create unique file name with ~
 
-    bool shortenName(char *nLong, char *nShort);
-    bool shortenExtension(char *shortFileName, char *nLongExt, char *nShortExt);
+    bool shortenName(const char *nLong, char *nShort);
+    bool shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt);
 
     static int  strCharPos(const char *str, int maxLen, char ch);
     static void replaceNonLetters(char *str);


### PR DESCRIPTION
1) fix: use last period '.' to start the file extension
2) make use of the extension for shortening long file names without extension.
