### PR TITLE
Various fixes to Dirtranslator/filenameshortener

### DIFF
--- a/ce_main_app/translated/dirtranslator.cpp
+++ b/ce_main_app/translated/dirtranslator.cpp
@@ -158,6 +158,8 @@ FilenameShortener *DirTranslator::createShortener(const std::string &path)
 			Debug::out(LOG_DEBUG, "TranslatedDisk::createShortener -- skipped %s because the type %d is not supported!", de->d_name, de->d_type);
 			continue;
 		}
+		if(strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+			continue;
 
 		fs->longToShortFileName(de->d_name, shortName);
     }

--- a/ce_main_app/translated/dirtranslator.cpp
+++ b/ce_main_app/translated/dirtranslator.cpp
@@ -41,41 +41,31 @@ void DirTranslator::clear(void)
     mapPathToShortener.clear();
 }
 
-void DirTranslator::shortToLongPath(std::string &rootPath, std::string &shortPath, std::string &longPath)
+void DirTranslator::shortToLongPath(const std::string &rootPath, const std::string &shortPath, std::string &longPath)
 {
     #define MAX_DIR_NESTING     64
     static char longName[MAX_FILENAME_LEN];
 
     std::string strings[MAX_DIR_NESTING];
-    int start = 0, pos;
+    unsigned int start = 0;
     unsigned int i, found = 0;
 
     // replace all possible atari path separators to host path separators
-    for(i=0; i<shortPath.length(); i++) {
-        if(shortPath[i] == ATARIPATH_SEPAR_CHAR) {
-            shortPath[i] = HOSTPATH_SEPAR_CHAR;
-        }
-    }
 
     // first split the string by separator
-    while(1) {
-        pos = shortPath.find(HOSTPATH_SEPAR_CHAR, start);
+    for(i = 0; i < shortPath.length(); i++) {
+		if(shortPath[i] != ATARIPATH_SEPAR_CHAR && shortPath[i] != HOSTPATH_SEPAR_CHAR)
+			continue;
 
-        if(pos == -1) {                             // not found?
-            strings[found] = shortPath.substr(start);    // copy in the rest
-            found++;
-            break;
-        }
-
-        strings[found] = shortPath.substr(start, (pos - start));
+        strings[found] = shortPath.substr(start, (i - start));
         found++;
-
-        start = pos + 1;
-
+        start = i + 1;
         if(found >= MAX_DIR_NESTING) {              // sanitize possible overflow
             break;
         }
     }
+    strings[found] = shortPath.substr(start);    // copy in the rest
+    found++;
 
     // now convert all the short names to long names
     bool res;

--- a/ce_main_app/translated/dirtranslator.h
+++ b/ce_main_app/translated/dirtranslator.h
@@ -34,7 +34,7 @@ public:
     void clear(void);
 
     // convert single filename from long to short
-    bool longToShortFilename(std::string &longHostPath, std::string &longFname, std::string &shortFname);
+    bool longToShortFilename(const std::string &longHostPath, const std::string &longFname, std::string &shortFname);
 
     // convert whole path from short to long
     void shortToLongPath(const std::string &rootPath, const std::string &shortPath, std::string &longPath);    // convert 'long_p~1\\sub_fo~1\\anothe~1' to 'long path/sub folder/another one'
@@ -48,7 +48,8 @@ private:
     TFindStorage    fsDirs;
     TFindStorage    fsFiles;
     
-    FilenameShortener *createShortener(std::string &path);
+	FilenameShortener *getShortenerForPath(std::string path);
+    FilenameShortener *createShortener(const std::string &path);
     static void splitFilenameFromPath(std::string &pathAndFile, std::string &path, std::string &file);
 
     void appendFoundToFindStorage(std::string &hostPath, const char *searchString, TFindStorage *fs, struct dirent *de, BYTE findAttribs);

--- a/ce_main_app/translated/dirtranslator.h
+++ b/ce_main_app/translated/dirtranslator.h
@@ -37,7 +37,7 @@ public:
     bool longToShortFilename(std::string &longHostPath, std::string &longFname, std::string &shortFname);
 
     // convert whole path from short to long
-    void shortToLongPath(std::string &rootPath, std::string &shortPath, std::string &longPath);    // convert 'long_p~1\\sub_fo~1\\anothe~1' to 'long path/sub folder/another one'
+    void shortToLongPath(const std::string &rootPath, const std::string &shortPath, std::string &longPath);    // convert 'long_p~1\\sub_fo~1\\anothe~1' to 'long path/sub folder/another one'
 
     // call this for find first / find next for Gemdos
     bool buildGemdosFindstorageData(TFindStorage *fs, std::string hostSearchPathAndWildcards, BYTE findAttribs, bool isRootDir, bool useZipdirNotFile);

--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "debug.h"
 #include "filenameshortener.h"
 #include "../utils.h"
 
@@ -58,7 +59,7 @@ bool FilenameShortener::longToShortFileName(const char *longFileName, char *shor
             strcpy(shortName, fileName);
         } else {
             if(!shortenNameUsingExt(fileName, shortName, shortExt)) {
-                printf("FilenameShortener::longToShortFileName failed to shortenName %s", fileName);
+                Debug::out(LOG_ERROR, "FilenameShortener::longToShortFileName failed to shortenName %s", fileName);
                 return false;
             }
         }
@@ -66,7 +67,7 @@ bool FilenameShortener::longToShortFileName(const char *longFileName, char *shor
         // there is an extension
         if(strlen(fileName) > 8) {                                  // filename too long? Shorten it.
             if(!shortenName(fileName, shortName)) {
-                printf("FilenameShortener::longToShortFileName failed to shortenName %s", fileName);
+                Debug::out(LOG_ERROR, "FilenameShortener::longToShortFileName failed to shortenName %s", fileName);
                 return false;
             }
         } else {                                                    // filename not long? ok...
@@ -75,7 +76,7 @@ bool FilenameShortener::longToShortFileName(const char *longFileName, char *shor
 
         if(strlen(fileExt) > 3) {                                  // file extension too long? Shorten it.
             if(!shortenExtension(shortName, fileExt, shortExt)) {
-                printf("FilenameShortener::longToShortFileName failed to shortenExtension %s.%s", shortName, fileExt);
+                Debug::out(LOG_ERROR, "FilenameShortener::longToShortFileName failed to shortenExtension %s.%s", shortName, fileExt);
                 return false;
             }
         } else {                                                    // file extension not long? ok...
@@ -94,6 +95,7 @@ bool FilenameShortener::longToShortFileName(const char *longFileName, char *shor
     mapFilenameWithExt.insert( std::pair<std::string, std::string>(longFn, shortFn) );  // store this key-value pair
     mapReverseFilename.insert( std::pair<std::string, std::string>(shortFn, longFn) );  // for reverse transformation
 
+	Debug::out(LOG_DEBUG, "FilenameShortener mapped %s <=> %s", shortFileName, longFileName);
     return true;
 }
 
@@ -159,7 +161,7 @@ void FilenameShortener::removeTrailingSpaces(char *str)
     }
 }
 
-bool FilenameShortener::shortToLongFileName(const char *shortFileName, char *longFileName)
+const bool FilenameShortener::shortToLongFileName(const char *shortFileName, char *longFileName)
 {
     if(strlen(shortFileName) == 0) {                            // empty short path? fail
         return false;
@@ -221,7 +223,7 @@ void FilenameShortener::splitFilenameFromExtension(const char *filenameWithExt, 
     }
 }
 
-bool FilenameShortener::shortenName(const char *nLong, char *nShort)
+const bool FilenameShortener::shortenName(const char *nLong, char *nShort)
 {
     int ind = 1;
     char num[12], newName[12];
@@ -253,7 +255,7 @@ bool FilenameShortener::shortenName(const char *nLong, char *nShort)
     return false;                                          // failed
 }
 
-bool FilenameShortener::shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt)
+const bool FilenameShortener::shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt)
 {
      int ind = 1;
 
@@ -278,9 +280,9 @@ bool FilenameShortener::shortenExtension(const char *shortFileName, const char *
 
     while(ind < 1000) {
         if(ind < 100) {                                     // according to the size of the number
-            sprintf(num, "~%d", ind);                       // numbers 1 .. 99 -> ~1 ~99
+            snprintf(num, sizeof(num), "~%d", ind);         // numbers 1 .. 99 -> ~1 ~99
         } else {
-            sprintf(num, "%d", ind);                        // numbers >= 100  -> 100 101 ...
+            snprintf(num, sizeof(num), "%d", ind);          // numbers >= 100  -> 100 101 ...
         }
 
         strncpy(newExt, nLongExt, 3);                       // get fist half, e.g. 'JPE'
@@ -304,7 +306,7 @@ bool FilenameShortener::shortenExtension(const char *shortFileName, const char *
     return false;                                           // this should never happen
 }
 
-bool FilenameShortener::shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt)
+const bool FilenameShortener::shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt)
 {
     // use 8 first characters as filename
     memcpy(shortName, fileName, 8);

--- a/ce_main_app/translated/filenameshortener.cpp
+++ b/ce_main_app/translated/filenameshortener.cpp
@@ -291,9 +291,9 @@ const bool FilenameShortener::shortenExtension(const char *shortFileName, const 
 
         mergeFilenameAndExtension(shortFileName, newExt, false, newName1);
 
-        it = mapFilenameWithExt.find(newName1);             // try to find the string in the map
+        it = mapReverseFilename.find(newName1);             // try to find the string in the map
 
-        if(it == mapFilenameWithExt.end()) {                // if we don't have this fileName already, use it!
+        if(it == mapReverseFilename.end()) {                // if we don't have this fileName already, use it!
             strncpy(nShortExt, newExt, 3);                  // store the extension string
             nShortExt[3] = 0;
 

--- a/ce_main_app/translated/filenameshortener.h
+++ b/ce_main_app/translated/filenameshortener.h
@@ -25,7 +25,7 @@ public:
     void clear(void);                                                       // clear maps - e.g. on ST restart
 
     bool longToShortFileName(const char *longFileName, char *shortFileName);      // translates 'long file name' to 'long_f~1'
-    bool shortToLongFileName(const char *shortFileName, char *longFileName);      // translates 'long_f~1' to 'long file name'
+    const bool shortToLongFileName(const char *shortFileName, char *longFileName);      // translates 'long_f~1' to 'long file name'
 
     static void mergeFilenameAndExtension(const char *shortFn, const char *shortExt, bool extendWithSpaces, char *merged);
 
@@ -40,9 +40,9 @@ private:
     std::map<std::string, std::string> mapFilenameNoExt;                    // used by shortenName() to create unique file name with ~
     bool allowExtUse;          // Allow use of Extension for shortening (if file without extension)
 
-    bool shortenName(const char *nLong, char *nShort);
-    bool shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt);
-    bool shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt);
+    const bool shortenName(const char *nLong, char *nShort);
+    const bool shortenExtension(const char *shortFileName, const char *nLongExt, char *nShortExt);
+    const bool shortenNameUsingExt(const char *fileName, char *shortName, char *shortExt);
 
     static int  strrCharPos(const char *str, int maxLen, char ch);
     static void replaceNonLetters(char *str);

--- a/ce_main_app/translated/translateddisk.h
+++ b/ce_main_app/translated/translateddisk.h
@@ -184,8 +184,8 @@ private:
     static bool isLetter(char a);
     static char toUpperCase(char a);
     static bool isValidDriveLetter(char a);
-    static bool pathContainsWildCards(char *path);
-    static int  deleteDirectoryPlain(char *path);
+    static bool pathContainsWildCards(const char *path);
+    static int  deleteDirectoryPlain(const char *path);
 
     static bool startsWith(std::string what, std::string subStr);
     static bool endsWith(std::string what, std::string subStr);

--- a/ce_main_app/translated/translateddisk_general.cpp
+++ b/ce_main_app/translated/translateddisk_general.cpp
@@ -1046,11 +1046,17 @@ int TranslatedDisk::deleteDirectoryPlain(const char *path)
 
 bool TranslatedDisk::isRootDir(std::string hostPath)
 {
+	// remove trailing '/' if needed
+	if(hostPath.size() > 0 && hostPath[hostPath.size() - 1] == HOSTPATH_SEPAR_CHAR) {
+		hostPath.erase(hostPath.size() - 1, 1);
+	}
+
     for(int i=2; i<MAX_DRIVES; i++) {                   // go through all translated drives
         if(!conf[i].enabled) {                          // skip disabled drives
             continue;
         }
         
+        //Debug::out(LOG_DEBUG, "TranslatedDisk::isRootDir - %s == %s ?", conf[i].hostRootPath.c_str(), hostPath.c_str());
         if(conf[i].hostRootPath == hostPath) {          // ok, this is root dir!
             Debug::out(LOG_DEBUG, "TranslatedDisk::isRootDir - hostPath: %s -- yes, it's a root dir", hostPath.c_str());
             return true;

--- a/ce_main_app/translated/translateddisk_general.cpp
+++ b/ce_main_app/translated/translateddisk_general.cpp
@@ -1040,7 +1040,7 @@ int TranslatedDisk::deleteDirectoryPlain(const char *path)
     if(res == 0) {              // on success return success
         return E_OK;
     }
-    
+    Debug::out(LOG_ERROR, "TranslatedDisk::deleteDirectoryPlain rmdir(%s) : %s", path, strerror(errno));
     return EACCDN;
 }
 

--- a/ce_main_app/translated/translateddisk_general.cpp
+++ b/ce_main_app/translated/translateddisk_general.cpp
@@ -1032,7 +1032,7 @@ void TranslatedDisk::pathSeparatorHostToAtari(std::string &path)
     }
 }
 
-int TranslatedDisk::deleteDirectoryPlain(char *path)
+int TranslatedDisk::deleteDirectoryPlain(const char *path)
 {
     // if the dir is empty, it will delete it, otherwise it will fail
     int res = rmdir(path);
@@ -1253,16 +1253,9 @@ void TranslatedDisk::initAsciiTranslationTable(void)
     asciiAtariToPc[184] = 'O';
 }
 
-bool TranslatedDisk::pathContainsWildCards(char *path)
+bool TranslatedDisk::pathContainsWildCards(const char *path)
 {
-    int i, len;
-    len = strlen(path);
-
-    if(len >= 2048) {                   // probably no terminating char? go only this far
-        len = 2048;
-    }
-
-    for(i=0; i<len; i++) {              // go through the string
+    for(int i=0; i<2048; i++) {         // go through the string. Limit length to 2048
         char in = path[i];
 
         if(in == 0) {                   // if it's string terminator, quit

--- a/ce_main_app/utils.cpp
+++ b/ce_main_app/utils.cpp
@@ -130,7 +130,7 @@ void Utils::fileDateTimeToHostTime(WORD atariDate, WORD atariTime, struct tm *pt
 	ptm->tm_sec		= seconds;
 }
 
-void Utils::mergeHostPaths(std::string &dest, std::string &tail)
+void Utils::mergeHostPaths(std::string &dest, const std::string &tail)
 {
     if(dest.empty()) {      // if the 1st part is empty, then result is just the 2nd part
         dest = tail;
@@ -159,11 +159,11 @@ void Utils::mergeHostPaths(std::string &dest, std::string &tail)
     dest = dest + tail;
 }
 
-void Utils::splitFilenameFromPath(std::string &pathAndFile, std::string &path, std::string &file)
+void Utils::splitFilenameFromPath(const std::string &pathAndFile, std::string &path, std::string &file)
 {
-    int sepPos = pathAndFile.rfind(HOSTPATH_SEPAR_STRING);
+    size_t sepPos = pathAndFile.rfind(HOSTPATH_SEPAR_STRING);
 
-    if(sepPos == ((int) std::string::npos)) {                   // not found?
+    if(sepPos == std::string::npos) {                   // not found?
         path.clear();
         file = pathAndFile;                                     // pretend we don't have path, just filename
     } else {                                                    // separator found?

--- a/ce_main_app/utils.h
+++ b/ce_main_app/utils.h
@@ -20,8 +20,8 @@ public:
 	static WORD fileTimeToAtariTime(struct tm *ptm);
 	static WORD fileTimeToAtariDate(struct tm *ptm);
 	
-	static void mergeHostPaths(std::string &dest, std::string &tail);
-	static void splitFilenameFromPath(std::string &pathAndFile, std::string &path, std::string &file);
+	static void mergeHostPaths(std::string &dest, const std::string &tail);
+	static void splitFilenameFromPath(const std::string &pathAndFile, std::string &path, std::string &file);
 
 	static void resetHansAndFranz(void);
     static void resetHans(void);


### PR DESCRIPTION
issues found and fixed today :
1- non working isRoot() because of trailing slashes.
2- Trailing slashes also cause of 2 shortener created for each path ( /some/path/ + /some/path)
3- issue in shortenExtension()
4- fileshortener was storing . and .. (as _____ and ._) !
5- very minor issue in pathContainsWildCards()

const added to many method prototypes, to clarify what are in arguments / out arguments !
=> then I found that shortToLongPath() modify it's "source" argument. Fixed that
