### PR TITLE
ce_dd.prg support $ make USE_LOWLEVEL_PEXEC=no

### DIFF
--- a/ce_dd_prg/Makefile
+++ b/ce_dd_prg/Makefile
@@ -1,6 +1,6 @@
 TARGET  = ce_dd.prg
 SLIM    = yes
-USE_LOWELEVEL_PEXEC = yes
+USE_LOWLEVEL_PEXEC = yes
 
 # control verbosity. use make V=1 to show commands
 V = 0
@@ -45,7 +45,7 @@ CSRC     = mutex.c xbra.c acsi.c scsi_falcon.c scsi_tt.c \
            hdd_if.c screen.c
 SSRC     = gemdos_asm.s bios_asm.s screenirq.s
 
-ifeq ($(USE_LOWELEVEL_PEXEC),yes)
+ifeq ($(USE_LOWLEVEL_PEXEC),yes)
     CSRC += gemdos_pexec_lowlevel.c
     SSRC += harddrive_lowlevel.s
 else

--- a/ce_dd_prg/Makefile
+++ b/ce_dd_prg/Makefile
@@ -43,13 +43,14 @@ CSRC     = mutex.c xbra.c acsi.c scsi_falcon.c scsi_tt.c \
            gemdos.c gemdos_rw.c \
            bios.c main.c find_ce.c \
            hdd_if.c screen.c
-SSRC     = gemdos_asm.s bios_asm.s screenirq.s \
-           harddrive_lowlevel.s
+SSRC     = gemdos_asm.s bios_asm.s screenirq.s
 
 ifeq ($(USE_LOWELEVEL_PEXEC),yes)
     CSRC += gemdos_pexec_lowlevel.c
+    SSRC += harddrive_lowlevel.s
 else
     CSRC += gemdos_pexec.c
+    CFLAGS += -DMANUAL_PEXEC
 endif
 
 ifeq ($(SLIM),yes)

--- a/ce_dd_prg/bios.c
+++ b/ce_dd_prg/bios.c
@@ -17,7 +17,11 @@
 #include "main.h"
 
 extern int16_t useOldBiosHandler;
-extern WORD ceDrives;
+#ifdef MANUAL_PEXEC
+WORD ceDrives;
+#else
+extern WORD ceDrives;	/* defined in harddrive_lowlevel.s */
+#endif
 extern WORD ceMediach;
 
 extern BYTE commandShort[CMD_LENGTH_SHORT];

--- a/ce_dd_prg/gemdos.c
+++ b/ce_dd_prg/gemdos.c
@@ -959,8 +959,6 @@ void initFunctionTable(void)
 
     // program execution functions
     
-//#define MANUAL_PEXEC
-    
 #ifdef MANUAL_PEXEC
     // manually handling Pexec() and Pterm*() functions
 	gemdos_table[GEMDOS_pexec]      = custom_pexec;

--- a/ce_dd_prg/gemdos.h
+++ b/ce_dd_prg/gemdos.h
@@ -113,7 +113,6 @@ void initFunctionTable(void);
 
 WORD getDriveFromPath(char *path);
 BYTE isOurDrive(WORD drive, BYTE withCurrentDrive);
-void updateCeDrives(void);
 
 int32_t custom_fread ( void *sp );
 int32_t custom_fwrite( void *sp );

--- a/ce_dd_prg/gemdos_pexec.c
+++ b/ce_dd_prg/gemdos_pexec.c
@@ -47,7 +47,6 @@ extern BYTE fsnextIsForUs;
 BYTE getNextDTAsFromHost(void);
 DWORD copyNextDtaToAtari(void);
 
-extern WORD ceDrives;
 extern BYTE currentDrive;
 
 #define PE_LOADGO		0

--- a/ce_dd_prg/main.c
+++ b/ce_dd_prg/main.c
@@ -14,6 +14,7 @@
 #include "hdd_if.h"
 #include "translated.h"
 #include "gemdos.h"
+#include "bios.h"
 #include "main.h"
 #include "mutex.h"
 


### PR DESCRIPTION
So it is easier to test without editing Makefile, c files, etc.
