### PR TITLE
Show USB drive label on Atari desktop

### DIFF
--- a/ce_main_app/translated/desktopcreator.cpp
+++ b/ce_main_app/translated/desktopcreator.cpp
@@ -196,7 +196,10 @@ char *DesktopCreator::storeExistingDrives(char *bfr, DesktopConfig *dc)
                     driveName = "SHARED DRIVE";
                     driveIcon = 0x06;
                 } else {                                    // it's a usb drive
-                    driveName = "USB DRIVE";
+                    if(!dc->label[i].empty())
+                        driveName = dc->label[i].c_str();
+                    else
+                        driveName = "USB DRIVE";
                     driveIcon = 0x08;
                 }
             }

--- a/ce_main_app/translated/desktopcreator.h
+++ b/ce_main_app/translated/desktopcreator.h
@@ -1,7 +1,10 @@
 #ifndef _DESKTOPCREATOR_H_
 #define _DESKTOPCREATOR_H_
 
+#include <string>
+
 #include "../datatypes.h"
+#include "translateddisk.h"
 
 #define TOSVER100   0x0100
 #define TOSVER102   0x0102
@@ -22,6 +25,7 @@ typedef struct {
     DWORD translatedDrives;     // bitmap of drives which are translated
     BYTE  configDrive;          // index of config drive
     BYTE  sharedDrive;          // index of shared drive
+    std::string label[MAX_DRIVES];
 } DesktopConfig;
 
 class DesktopCreator {

--- a/ce_main_app/translated/translateddisk.h
+++ b/ce_main_app/translated/translateddisk.h
@@ -28,6 +28,7 @@ typedef struct {
 
     std::string devicePath;                 // where the device is
     std::string hostRootPath;               // where is the root on host file system
+    std::string label;						// "DOS" label
     char        stDriveLetter;              // what letter will be used on ST
     std::string currentAtariPath;           // what is the current path on this drive
 
@@ -40,6 +41,7 @@ typedef struct {
     bool        enabled;
     std::string devicePath;                 // where the device is
     std::string hostRootPath;               // where is the root on host file system
+    std::string label;						// "DOS" label
     int         translatedType;             // normal / shared / config
 } TranslatedConfTemp;
 

--- a/ce_main_app/translated/translateddisk_general.cpp
+++ b/ce_main_app/translated/translateddisk_general.cpp
@@ -138,6 +138,7 @@ void TranslatedDisk::reloadSettings(int type)
         tmpConf[i].hostRootPath     = conf[i].hostRootPath;
         tmpConf[i].translatedType   = conf[i].translatedType;
         tmpConf[i].devicePath       = conf[i].devicePath;
+        tmpConf[i].label            = conf[i].label;
     }
 
     detachAll();                                // then deinit the conf structures
@@ -321,6 +322,7 @@ void TranslatedDisk::attachToHostPathByIndex(int index, std::string hostRootPath
     conf[index].currentAtariPath    = HOSTPATH_SEPAR_STRING;
     conf[index].translatedType      = translatedType;
     conf[index].mediaChanged        = true;
+    conf[index].label = Utils::getDeviceLabel(devicePath);
 
     Debug::out(LOG_DEBUG, "TranslatedDisk::attachToHostPath - path %s attached to index %d (letter %c)", hostRootPath.c_str(), index, 'A' + index);
 }
@@ -660,10 +662,13 @@ void TranslatedDisk::onInitialize(void)     // this method is called on the star
     
     Settings s;
     dc.settingsResolution   = s.getInt("SCREEN_RESOLUTION", 1);
-    
-    system("rm -f /tmp/configdrive/*.inf");             // remove any *.inf file
-    system("rm -f /tmp/configdrive/*.INF");             // remove any *.INF file, too
-    
+    for(int i = 2; i < MAX_DRIVES; i++) {
+        dc.label[i] = conf[i].label;
+    }
+
+    //system("rm -f /tmp/configdrive/*.inf");             // remove any *.inf file
+    //system("rm -f /tmp/configdrive/*.INF");             // remove any *.INF file, too
+
     DesktopCreator::createToFile(&dc);                  // create the DESKTOP.INF / NEWDESK.INF file
 
     dataTrans->setStatus(E_OK);

--- a/ce_main_app/utils.cpp
+++ b/ce_main_app/utils.cpp
@@ -468,3 +468,40 @@ void Utils::setTimezoneVariable_inThisContext(void)
     
     setenv("TZ", utcOfsset, 1);
 }
+
+std::string Utils::getDeviceLabel(const std::string & devicePath)
+{
+#define DEV_BY_LABEL_PATH "/dev/disk/by-label/"
+	std::string label("");
+
+	if(devicePath.substr(0,5) != "/dev/") return label;
+	std::string devShort = devicePath.substr(5);
+
+	DIR *d = opendir(DEV_BY_LABEL_PATH);
+	if(d != NULL) {
+		FILE *f = fopen("/tmp/labels.txt", "w");
+		fprintf(f, "%s\n", devShort.c_str());
+		struct dirent * de;
+		char link_path[256];
+		char link_target[256];
+		while((de = readdir(d)) != NULL) {
+			if(de->d_type == DT_LNK) {	// symbolic link
+				snprintf(link_path, sizeof(link_path), "%s%s", DEV_BY_LABEL_PATH, de->d_name);
+				ssize_t n = readlink(link_path, link_target, sizeof(link_target) - 1);
+				fprintf(f, "%s %d\n", link_path, (int)n);
+				if(n >= 0) {
+					link_target[n] = '\0';
+					char * target_short = strrchr(link_target, '/');
+					if(target_short != NULL) {
+						target_short++;
+						if(devShort == target_short) label = de->d_name;
+						fprintf(f, "%x %s %s\n", de->d_type, de->d_name, target_short);
+					}
+				}
+			}
+		}
+		fclose(f);
+		closedir(d);
+	}
+	return label;
+}

--- a/ce_main_app/utils.cpp
+++ b/ce_main_app/utils.cpp
@@ -479,8 +479,8 @@ std::string Utils::getDeviceLabel(const std::string & devicePath)
 
 	DIR *d = opendir(DEV_BY_LABEL_PATH);
 	if(d != NULL) {
-		FILE *f = fopen("/tmp/labels.txt", "w");
-		fprintf(f, "%s\n", devShort.c_str());
+		//FILE *f = fopen("/tmp/labels.txt", "w");
+		//fprintf(f, "%s\n", devShort.c_str());
 		struct dirent * de;
 		char link_path[256];
 		char link_target[256];
@@ -488,19 +488,19 @@ std::string Utils::getDeviceLabel(const std::string & devicePath)
 			if(de->d_type == DT_LNK) {	// symbolic link
 				snprintf(link_path, sizeof(link_path), "%s%s", DEV_BY_LABEL_PATH, de->d_name);
 				ssize_t n = readlink(link_path, link_target, sizeof(link_target) - 1);
-				fprintf(f, "%s %d\n", link_path, (int)n);
+				//fprintf(f, "%s %d\n", link_path, (int)n);
 				if(n >= 0) {
 					link_target[n] = '\0';
 					char * target_short = strrchr(link_target, '/');
 					if(target_short != NULL) {
 						target_short++;
 						if(devShort == target_short) label = de->d_name;
-						fprintf(f, "%x %s %s\n", de->d_type, de->d_name, target_short);
+						//fprintf(f, "%x %s %s\n", de->d_type, de->d_name, target_short);
 					}
 				}
 			}
 		}
-		fclose(f);
+		//fclose(f);
 		closedir(d);
 	}
 	return label;

--- a/ce_main_app/utils.h
+++ b/ce_main_app/utils.h
@@ -48,6 +48,7 @@ public:
     static void setTimezoneVariable_inProfileScript(void);
     static void setTimezoneVariable_inThisContext(void);
 
+    static std::string getDeviceLabel(const std::string & devicePath);
 private:
     static bool copyFileByHandles(FILE *from, FILE *to);
 


### PR DESCRIPTION
instead of showing only "USB DRIVE", now the real "MSDOS" volume label is shown, as on Windows ;)
I tested with FAT/FAT32 formated sticks with the Yocto.
Have to be tested on raspbian
