### PR TITLE
Hdd images : a few fixes

### DIFF
--- a/ce_main_app/ccorethread.cpp
+++ b/ce_main_app/ccorethread.cpp
@@ -124,7 +124,6 @@ void CCoreThread::sharedObjects_create(ConfigService* configService, FloppyServi
 
     shared.scsi        = new Scsi();
     shared.scsi->setAcsiDataTrans(dataTrans);
-    shared.scsi->attachToHostPath(TRANSLATEDBOOTMEDIA_FAKEPATH, SOURCETYPE_IMAGE_TRANSLATEDBOOT, SCSI_ACCESSTYPE_FULL);
 
     shared.translated = new TranslatedDisk(dataTrans, configService, screencastService);
     shared.translated->setSettingsReloadProxy(&settingsReloadProxy);

--- a/ce_main_app/config/configstream.h
+++ b/ce_main_app/config/configstream.h
@@ -22,7 +22,7 @@ enum CS_ACTION { CS_CREATE_ACSI = 1,    CS_CREATE_TRANSLATED,   CS_CREATE_SHARED
                  CS_CREATE_FLOPPY_CONF, CS_CREATE_IKBD,         CS_CREATE_HDDIMAGE,
                  CS_CREATE_NETWORK,     CS_CREATE_UPDATE,       CS_CREATE_OTHER,
                  CS_SAVE_ACSI,          CS_SAVE_TRANSLATED,     CS_SAVE_NETWORK,
-                 CS_HDDIMAGE_SAVE,
+                 CS_HDDIMAGE_SAVE,      CS_HDDIMAGE_CLEAR,
                  CS_HIDE_MSG_SCREEN,    CS_GO_HOME,
                  CS_UPDATE_CHECK,       CS_UPDATE_CHECK_USB,    CS_UPDATE_UPDATE,
                  CS_SHARED_TEST,        CS_SHARED_SAVE,
@@ -34,7 +34,7 @@ enum CS_ACTION { CS_CREATE_ACSI = 1,    CS_CREATE_TRANSLATED,   CS_CREATE_SHARED
 
 enum COMPIDS {  COMPID_TRAN_FIRST = 1,      COMPID_TRAN_SHARED,         COMPID_TRAN_CONFDRIVE,
                 COMPID_MOUNT_RAW_NOT_TRANS, 
-                COMPID_BTN_SAVE,            COMPID_BTN_CANCEL,
+                COMPID_BTN_SAVE,            COMPID_BTN_CANCEL,          COMPID_BTN_CLEAR,
                 COMPID_USE_ZIP_DIR_NOT_FILE,
 
                 COMPID_HOSTNAME,
@@ -173,6 +173,7 @@ private:
     void getProgressLine(int index, std::string &lines, std::string &line);
 
     void onHddImageSave(void);
+    void onHddImageClear(void);
 
     void onSharedTest(void);
     void onSharedSave(void);

--- a/ce_main_app/config/configstream_general.cpp
+++ b/ce_main_app/config/configstream_general.cpp
@@ -729,6 +729,7 @@ void ConfigStream::enterKeyHandler(int event)
     case CS_SEND_SETTINGS:      onSendSettings();           break;
 
     case CS_HDDIMAGE_SAVE:      onHddImageSave();           break;
+    case CS_HDDIMAGE_CLEAR:     onHddImageClear();          break;
 //  case CS_SHARED_TEST:        onSharedTest();             break;
     case CS_SHARED_SAVE:        onSharedSave();             break;
 

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -1604,15 +1604,21 @@ void ConfigStream::createScreen_hddimage(void)
     row++;
 
     comp = new ConfigComponent(this, ConfigComponent::button, "  Save  ",
-                               8, /*15*/ 9, row, gotoOffset);
+                               8, 3, row, gotoOffset);
     comp->setOnEnterFunctionCode(CS_HDDIMAGE_SAVE);
     comp->setComponentId(COMPID_BTN_SAVE);
     screen.push_back(comp);
 
     comp = new ConfigComponent(this, ConfigComponent::button, " Cancel ",
-                               8, /*27*/ 21, row, gotoOffset);
+                               8, 15, row, gotoOffset);
     comp->setOnEnterFunctionCode(CS_GO_HOME);
     comp->setComponentId(COMPID_BTN_CANCEL);
+    screen.push_back(comp);
+
+    comp = new ConfigComponent(this, ConfigComponent::button, "  Clear ",
+                               8, 27, row, gotoOffset);
+    comp->setOnEnterFunctionCode(CS_HDDIMAGE_CLEAR);
+    comp->setComponentId(COMPID_BTN_CLEAR);
     screen.push_back(comp);
     row += 2;
 
@@ -1797,6 +1803,12 @@ void ConfigStream::onHddImageSave(void)
     Utils::forceSync();                                     // tell system to flush the filesystem caches
 
     createScreen_homeScreen();      // now back to the home screen
+}
+
+void ConfigStream::onHddImageClear(void)
+{
+    std::string path("");
+    setTextByComponentId(COMPID_HDDIMAGE_PATH, path);
 }
 
 void ConfigStream::onSharedTest(void)

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -2,6 +2,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <algorithm>
 
@@ -1790,10 +1793,25 @@ void ConfigStream::createScreen_shared(void)
 
 void ConfigStream::onHddImageSave(void)
 {
+    struct stat st;
     std::string path;
 
     getTextByComponentId(COMPID_HDDIMAGE_PATH, path);
 
+    if(!path.empty()) {
+        if(stat(path.c_str(), &st) < 0) {
+            showMessageScreen("Warning", "Cannot access file.\n\rPlease fix this and try again.");
+            return;
+        } else {
+            if(!S_ISREG(st.st_mode)) {
+                showMessageScreen("Warning", "File is not regular file.\n\rPlease fix this and try again.");
+                return;
+            }
+        }
+    }
+    if(path.find("/mnt/shared/") == 0) {
+        showMessageScreen("Warning", "It is not safe to mount HDD Image from\r\nnetwork.");
+    }
     Settings s;
     s.setString("HDDIMAGE", path.c_str());
 

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -1597,7 +1597,8 @@ void ConfigStream::createScreen_hddimage(void)
     screen.push_back(comp);
 
     comp = new ConfigComponent(this, ConfigComponent::editline, " ",
-                               38, 0, row++, gotoOffset);
+                               255, 0, row++, gotoOffset);
+    comp->setLimitedShowSize(38);   /* only show 38 characters */
     comp->setComponentId(COMPID_HDDIMAGE_PATH);
     screen.push_back(comp);
 

--- a/ce_main_app/native/scsi.cpp
+++ b/ce_main_app/native/scsi.cpp
@@ -387,12 +387,18 @@ void Scsi::loadSettings(void)
         attachToHostPath(empty, SOURCETYPE_SD_CARD, SCSI_ACCESSTYPE_FULL);
     }
 
+    // attach Translated bootmedia
+    attachToHostPath(TRANSLATEDBOOTMEDIA_FAKEPATH, SOURCETYPE_IMAGE_TRANSLATEDBOOT, SCSI_ACCESSTYPE_FULL);
+
+    // TODO : attach RAW usb drives again
+#if 0
     // and now reattach everything back according to new ACSI ID settings
     for(int i=0; i<MAX_ATTACHED_MEDIA; i++) {
         if(attachedMedia[i].dataMedia != NULL) {            // if there's some media to use
             attachMediaToACSIid(i, attachedMedia[i].hostSourceType, attachedMedia[i].accessType);
         }
     }
+#endif
 
     std::string img;
     img = s.getString("HDDIMAGE", "");

--- a/ce_main_app/settingsreloadproxy.h
+++ b/ce_main_app/settingsreloadproxy.h
@@ -1,3 +1,4 @@
+// vim: expandtab shiftwidth=4 tabstop=4
 #ifndef SETTINGSRELOADPROXY_H
 #define SETTINGSRELOADPROXY_H
 
@@ -6,7 +7,7 @@
 #define SETTINGSUSER_NONE           0
 #define SETTINGSUSER_ACSI           1
 #define SETTINGSUSER_TRANSLATED     2
-#define SETTINGSUSER_SHARED		    3
+#define SETTINGSUSER_SHARED         3
 #define SETTINGSUSER_FLOPPYCONF     4
 #define SETTINGSUSER_FLOPPYIMGS     5
 #define SETTINGSUSER_FLOPPY_SLOT    6


### PR DESCRIPTION
fixes a few issues noted in #77 
- show warning in config screen for non existing files
- show warning for images mounted from /mnt/shared

add a "clear" button
use new scrollable config field