### PR TITLE
Extended key joystick functionality + IKBD fixes

### DIFF
--- a/ce_conf/keys.h
+++ b/ce_conf/keys.h
@@ -26,8 +26,4 @@
 #define		KEY_F9		158
 #define		KEY_F10		159
 
-#define     KEY_CTRL_C  0x03        // end of text
-#define     KEY_CTRL_K  161
-#define     KEY_CTRL_L  0x0c        // form feed
-#define     KEY_CTRL_U  163
-
+#define		KEY_SHIFT_TAB	160

--- a/ce_conf/main.c
+++ b/ce_conf/main.c
@@ -27,7 +27,7 @@ BYTE setResolution(void);
 void showConnectionErrorMessage(void);
 void showMoreStreamIfNeeded(void);
 
-BYTE atariKeysToSingleByte(BYTE vkey, BYTE key);
+BYTE atariKeysToSingleByte(BYTE vkey, BYTE key, int, int);
 BYTE ce_identify(BYTE ACSI_id);
 
 BYTE retrieveIsUpdating    (void);
@@ -319,7 +319,7 @@ void showConnectionErrorMessage(void)
     prevCommandFailed = 1;
 }
 //--------------------------------------------------
-BYTE atariKeysToSingleByte(BYTE vkey, BYTE key)
+BYTE atariKeysToSingleByte(BYTE vkey, BYTE key, int shift, int ctrl)
 {
     WORD vkeyKey;
 
@@ -357,13 +357,9 @@ BYTE atariKeysToSingleByte(BYTE vkey, BYTE key)
         case 0x011b: return KEY_ESC;
         case 0x537f: return KEY_DELETE;
         case 0x0e08: return KEY_BACKSP;
-        case 0x0f09: return KEY_TAB;
+        case 0x0f09: return shift ? KEY_SHIFT_TAB : KEY_TAB;
         case 0x1c0d: return KEY_ENTER;
         case 0x720d: return KEY_ENTER;
-        case 0x2e03: return KEY_CTRL_C;
-        case 0x250b: return KEY_CTRL_K;
-        case 0x260c: return KEY_CTRL_L;
-        case 0x1615: return KEY_CTRL_U;
     }
 
     return 0;                           // unknown key 
@@ -571,7 +567,7 @@ void showFakeProgress(void)
 
 BYTE getKeyIfPossible(void)
 {
-    DWORD scancode;
+    DWORD scancode, special;
     BYTE key, vkey, res;
 
     res = Cconis();                             // see if there's something waiting from keyboard 
@@ -581,11 +577,12 @@ BYTE getKeyIfPossible(void)
     }
     
     scancode = Cnecin();                        // get char form keyboard, no echo on screen 
+    special  = Kbshift(-1);
 
     vkey    = (scancode>>16)    & 0xff;
     key     =  scancode         & 0xff;
 
-    key     = atariKeysToSingleByte(vkey, key); // transform BYTE pair into single BYTE
+    key     = atariKeysToSingleByte(vkey, key, special & 0x03, special & 0x04); // transform BYTE pair into single BYTE
     return key;
 }
 //--------------------------------------------------

--- a/ce_main_app/ce_conf_on_rpi.cpp
+++ b/ce_main_app/ce_conf_on_rpi.cpp
@@ -19,7 +19,7 @@
 #include "config/configstream.h"
 #include "config/keys.h"
 
-#include "ce_conf_on_rpi.h" 
+#include "ce_conf_on_rpi.h"
 #include "periodicthread.h"
 
 extern SharedObjects shared;
@@ -35,7 +35,7 @@ int translateVT52toVT100(BYTE *bfr, BYTE *tmp, int cnt)
     int i, t = 0;
 
     memset(tmp, 0, INBFR_SIZE);
-    
+
     for(i=0; i<cnt; ) {
         if(bfr[i] == 27) {
             switch(bfr[i + 1]) {
@@ -45,7 +45,7 @@ int translateVT52toVT100(BYTE *bfr, BYTE *tmp, int cnt)
                     strcat((char *) tmp, "\033[40m");        // background black
                     strcat((char *) tmp, "\033[2J");         // clear whole screen
                     strcat((char *) tmp, "\033[H");          // position cursor to 0,0
-                    
+
                     t += 5 + 5 + 4 + 3;
                     i += 2;
                     break;
@@ -54,7 +54,7 @@ int translateVT52toVT100(BYTE *bfr, BYTE *tmp, int cnt)
                     int x, y;
                     y = bfr[i+2] - 32;
                     x = bfr[i+3] - 32;
-                    
+
                     char tmp2[16];
                     sprintf(tmp2, "\033[%d;%dH", y, x);
                     strcat((char *) tmp, tmp2);
@@ -81,14 +81,14 @@ int translateVT52toVT100(BYTE *bfr, BYTE *tmp, int cnt)
                 //------------------------
                 case 'e':               // cursor on
                     strcat((char *) tmp, "\033[?25h");
-                    
+
                     t += 6;
                     i += 2;
                     break;
                 //------------------------
                 case 'f':               // cursor off
                     strcat((char *) tmp, "\033[?25l");
-                    
+
                     t += 6;
                     i += 2;
                     break;
@@ -97,12 +97,12 @@ int translateVT52toVT100(BYTE *bfr, BYTE *tmp, int cnt)
                     printf("Unknown ESC sequence: %02d %02d \n", bfr[i], bfr[i+1]);
                     i += 2;
                     break;
-            }            
+            }
         } else {
             tmp[t++] = bfr[i++];
         }
     }
-    
+
     memcpy(bfr, tmp, t);             // copy back the converted data
     return t;
 }
@@ -125,16 +125,16 @@ bool sendCmd(BYTE cmd, BYTE param, int fd1, int fd2, BYTE *dataBuffer, BYTE *tem
     bfr[0] = HOSTMOD_CONFIG;
     bfr[1] = cmd;
     bfr[2] = param;
-    
+
     res = write(fd1, bfr, 3);                                   // send command
-    
+
     if(res != 3) {
         printf("sendCmd -- write failed!\n");
         return false;
     }
 
     WORD howManyBytes;
-    
+
     bool bRes = receiveStream(2, (BYTE *) &howManyBytes, fd2);  // first receive byte count that we should read
 
     if(!bRes) {                                                 // didn't receive available byte count?
@@ -150,7 +150,7 @@ bool sendCmd(BYTE cmd, BYTE param, int fd1, int fd2, BYTE *dataBuffer, BYTE *tem
         }
 
         printf("sendCmd -- failed to receive byte count\n");
-        
+
         Debug::out(LOG_DEBUG, "sendCmd fail on receiving howManyBytes");
         return false;
     }
@@ -164,7 +164,7 @@ bool sendCmd(BYTE cmd, BYTE param, int fd1, int fd2, BYTE *dataBuffer, BYTE *tem
 
     if(bRes) {
         vt100byteCount = translateVT52toVT100(dataBuffer, tempBuffer, howManyBytes);    // translate VT52 stream to VT100 stream
-        
+
         Debug::out(LOG_DEBUG, "sendCmd success, %d bytes of VT52 translated to %d bytes of VT100", howManyBytes, vt100byteCount);
     } else {
         Debug::out(LOG_DEBUG, "sendCmd fail on getting VT52 stream");
@@ -193,15 +193,15 @@ static bool receiveStream(int byteCount, BYTE *data, int fd)
     DWORD timeOutTime = Utils::getEndTime(1000);
 
     int recvCount = 0;          // how many VT52  chars we already got
-    
+
     BYTE *ptr = data;
-    
+
     while(recvCount < byteCount) {                                          // receive all the data, wait up to 1 second to receive it
         if(Utils::getCurrentMs() >= timeOutTime) {                          // time out happened, nothing received within specified timeout? fail
             Debug::out(LOG_DEBUG, "receiveStream - fail, wanted %d and got only %d bytes", byteCount, recvCount);
             return false;
         }
-    
+
         int bytesAvailable;
         int res = ioctl(fd, FIONREAD, &bytesAvailable);                     // how many bytes we can read?
 
@@ -214,20 +214,29 @@ static bool receiveStream(int byteCount, BYTE *data, int fd)
 
             recvCount   += readCount;
             ptr             += readCount;
-            
+
             Debug::out(LOG_DEBUG, "receiveStream - readCount: %d", readCount);
         }
 
         Utils::sleepMs(10);     // sleep a little
     }
-    
+
     Debug::out(LOG_DEBUG, "receiveStream - success, %d bytes", byteCount);
-    return true;    
+    return true;
+}
+
+static int safe_getchar(int *count) {
+    if (*count > 0) {
+        --(*count);
+        return getchar();
+    } else {
+        return 0;
+    }
 }
 
 static BYTE getKey(int count)
 {
-    int c = getchar();
+    int c = safe_getchar(&count);
 
     if(c != 27) {           // not ESC sequence? just return value
         switch(c) {
@@ -235,95 +244,95 @@ static BYTE getKey(int count)
             case 0x7f:  return KEY_BACKSP;
             case 0x09:  return KEY_TAB;
         }
-    
+
         return c;
     }
 
     // if we came here, it's ESC or ESC sequence
-    if(count == 1) {        // just esc? return it
+    if(count == 0) {        // just esc? return it
         return KEY_ESC;
     }
+    int a = safe_getchar(&count);
+    int b = safe_getchar(&count);
 
-    int a, b;
-    a = getchar();
-    b = getchar();
-    
+    int res = 0;
     if(a == 0x5b) {
         switch(b) {
-            case 0x41:    return KEY_UP;
-            case 0x42:    return KEY_DOWN;
-            case 0x43:    return KEY_RIGHT;
-            case 0x44:    return KEY_LEFT;
-            
+            case 0x41: res = KEY_UP;    break;
+            case 0x42: res = KEY_DOWN;  break;
+            case 0x43: res = KEY_RIGHT; break;
+            case 0x44: res = KEY_LEFT;  break;
+
             case 0x31:
-                c = getchar();
+                c = safe_getchar(&count);
                 if(c == 0x7e) {
-                    return KEY_HOME;
-                } else if(c == 0x37) {
-                    c = getchar();
+                    res = KEY_HOME;
+                } else if(c == 0x35) {
+                    c = safe_getchar(&count);
                     if(c == 0x7e) {
-                        return KEY_F6;
+                        res = KEY_F5;
+                    }
+                } else if(c == 0x37) {
+                    c = safe_getchar(&count);
+                    if(c == 0x7e) {
+                        res = KEY_F6;
                     }
                 } else if(c == 0x38) {
-                    c = getchar();
+                    c = safe_getchar(&count);
                     if(c == 0x7e) {
-                        return KEY_F7;
+                        res = KEY_F7;
                     }
                 } else if(c == 0x39) {
-                    c = getchar();
+                    c = safe_getchar(&count);
                     if(c == 0x7e) {
-                        return KEY_F8;
+                        res =KEY_F8;
                     }
                 }
                 break;
 
             case 0x32:
-                c = getchar();
+                c = safe_getchar(&count);
                 if(c == 0x7e) {
-                    return KEY_INSERT;
+                    res =KEY_INSERT;
                 } else if(c == 0x30) {
-                    c = getchar();
+                    c = safe_getchar(&count);
                     if(c == 0x7e) {
-                        return KEY_F9;
+                        res = KEY_F9;
                     }
                 } else if(c == 0x31) {
-                    c = getchar();
+                    c = safe_getchar(&count);
                     if(c == 0x7e) {
-                        return KEY_F10;
+                        res = KEY_F10;
                     }
                 }
                 break;
-                
+
             case 0x33:
-                c = getchar();
+                c = safe_getchar(&count);
                 if(c == 0x7e) {
-                    return KEY_DELETE;
+                    res = KEY_DELETE;
                 }
                 break;
-                
+
             case 0x34:
-                c = getchar();
+                c = safe_getchar(&count);
                 if(c == 0x7e) {
-                    return KEY_END;
+                    res = KEY_END;
                 }
                 break;
 
-            case 0x5a: return KEY_SHIFT_TAB;
-
-            case 0x5b:
-                c = getchar();
-                switch(c) {
-                    case 0x41:  return KEY_F1;
-                    case 0x42:  return KEY_F2;
-                    case 0x43:  return KEY_F3;
-                    case 0x44:  return KEY_F4;
-                    case 0x45:  return KEY_F5;
-                }
-                break;
+            case 0x5a: res = KEY_SHIFT_TAB; break;
+        }
+    } else if (a == 0x4f) {
+        switch (b) {
+            case 0x50: res = KEY_F1; break;
+            case 0x51: res = KEY_F2; break;
+            case 0x52: res = KEY_F3; break;
+            case 0x53: res = KEY_F4; break;
         }
     }
 
-    return 0;
+    return count == 0 ? res : 0;
 }
 
 void ce_conf_mainLoop(void)
@@ -332,7 +341,7 @@ void ce_conf_mainLoop(void)
 
     inBfr   = new BYTE[INBFR_SIZE];
     tmpBfr  = new BYTE[INBFR_SIZE];
-    
+
     termFd1 = open(FIFO_TERM_PATH1, O_RDWR);             // will be used for writing only
     termFd2 = open(FIFO_TERM_PATH2, O_RDWR);             // will be used for reading only
 
@@ -340,46 +349,46 @@ void ce_conf_mainLoop(void)
         printf("ce_conf_mainLoop -- open() failed: %s\n", strerror(errno));
         return;
     }
-    
+
     bool res;
     int vt100count;
     res = sendCmd(CFG_CMD_SET_RESOLUTION, ST_RESOLUTION_HIGH, termFd1, termFd2, inBfr, tmpBfr, vt100count);
-    
+
     if(res) {
         write(STDOUT_FILENO, (char *) inBfr, vt100count);
     }
-    
-  	struct termios old_tio_in, new_tio_in;
-  	struct termios old_tio_out, new_tio_out;
 
-	tcgetattr(STDIN_FILENO, &old_tio_in);           // get the terminal settings for stdin
-	new_tio_in = old_tio_in;                        // we want to keep the old setting to restore them a the end
-	new_tio_in.c_lflag &= (~ICANON & ~ECHO);        // disable canonical mode (buffered i/o) and local echo
-	tcsetattr(STDIN_FILENO, TCSANOW, &new_tio_in);  // set the new settings immediately
+    struct termios old_tio_in, new_tio_in;
+    struct termios old_tio_out, new_tio_out;
 
-	tcgetattr(STDOUT_FILENO,&old_tio_out);          // get the terminal settings for stdout
-	new_tio_out = old_tio_out;                      // we want to keep the old setting to restore them a the end
-	new_tio_out.c_lflag &= (~ICANON);               // disable canonical mode (buffered i/o)
-	tcsetattr(STDOUT_FILENO,TCSANOW, &new_tio_out); // set the new settings immediately
-    
+    tcgetattr(STDIN_FILENO, &old_tio_in);           // get the terminal settings for stdin
+    new_tio_in = old_tio_in;                        // we want to keep the old setting to restore them a the end
+    new_tio_in.c_lflag &= (~ICANON & ~ECHO);        // disable canonical mode (buffered i/o) and local echo
+    tcsetattr(STDIN_FILENO, TCSANOW, &new_tio_in);  // set the new settings immediately
+
+    tcgetattr(STDOUT_FILENO,&old_tio_out);          // get the terminal settings for stdout
+    new_tio_out = old_tio_out;                      // we want to keep the old setting to restore them a the end
+    new_tio_out.c_lflag &= (~ICANON);               // disable canonical mode (buffered i/o)
+    tcsetattr(STDOUT_FILENO,TCSANOW, &new_tio_out); // set the new settings immediately
+
     DWORD lastUpdate = 0;
-    
+
     while(sigintReceived == 0) {
         bool didSomething = false;
-    
+
         // check if something waiting from keyboard, and if so, read it
         int bytesAvailable;
         int res = ioctl(STDIN_FILENO, FIONREAD, &bytesAvailable);   // how many bytes we can read from keyboard?
-    
+
         if(res != -1 && bytesAvailable > 0) {
             didSomething = true;
-            
+
             BYTE key = getKey(bytesAvailable);                      // get the key in format valid for config components
-            
+
             if(key == KEY_F10) {                                    // should quit? do it
                 break;
             }
-            
+
             if(key == KEY_F8) {                                     // if should switch between config view and linux console view
                 write(STDOUT_FILENO, "\033[37m", 5);                // foreground white
                 write(STDOUT_FILENO, "\033[40m", 5);                // background black
@@ -389,45 +398,45 @@ void ce_conf_mainLoop(void)
                 configNotLinuxConsole = !configNotLinuxConsole;
                 key = 0;
             }
-            
+
             if(key != 0) {                                          // if got the key, send key down event
                 res = sendCmd(configNotLinuxConsole ? CFG_CMD_KEYDOWN : CFG_CMD_LINUXCONSOLE_GETSTREAM, key, termFd1, termFd2, inBfr, tmpBfr, vt100count);
-                
+
                 if(res) {
-                    int len = strnlen((const char *) inBfr, vt100count);    // get real string length - might have 2 more bytes (isUpdateScreen, updateComponents) after string terminator  
+                    int len = strnlen((const char *) inBfr, vt100count);    // get real string length - might have 2 more bytes (isUpdateScreen, updateComponents) after string terminator
                     write(STDOUT_FILENO, (char *) inBfr, len);
                 }
-                
+
                 lastUpdate = Utils::getCurrentMs();                 // store current time as we just updated
             }
         }
-        
+
         //-----------
         // should do refresh or nothing?
         if(Utils::getCurrentMs() - lastUpdate >= 1000) {            // last update more than 1 second ago? refresh
             didSomething = true;
-        
+
             res = sendCmd(configNotLinuxConsole ? CFG_CMD_REFRESH : CFG_CMD_LINUXCONSOLE_GETSTREAM, 0, termFd1, termFd2, inBfr, tmpBfr, vt100count);
-        
+
             if(res) {
                 int len = strnlen((const char *) inBfr, vt100count);    // get real string length - might have 2 more bytes (isUpdateScreen, updateComponents) after string terminator
                 write(STDOUT_FILENO, (char *) inBfr, len);
             }
 
             lastUpdate = Utils::getCurrentMs();                     // store current time as we just updated
-        } 
-        
+        }
+
         if(!didSomething) {         // if nothing happened in this loop, wait a little
             Utils::sleepMs(10);
         }
     }
-    
-	tcsetattr(STDIN_FILENO, TCSANOW, &old_tio_in);      // restore the former settings
-	tcsetattr(STDOUT_FILENO, TCSANOW, &old_tio_out);    // restore the former settings
-    
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &old_tio_in);      // restore the former settings
+    tcsetattr(STDOUT_FILENO, TCSANOW, &old_tio_out);    // restore the former settings
+
     delete []inBfr;
     delete []tmpBfr;
-    
+
     system("reset");
 }
 void ce_conf_createFifos(ConfigPipes *cp, char *path1, char *path2);
@@ -471,6 +480,6 @@ void ce_conf_createFifos(ConfigPipes *cp, char *path1, char *path2)
         Debug::out(LOG_ERROR, "ce_conf_createFifos -- fcntl() failed");
         return;
     }
-    
+
     Debug::out(LOG_DEBUG, "ce_conf FIFOs created");
 }

--- a/ce_main_app/ce_conf_on_rpi.cpp
+++ b/ce_main_app/ce_conf_on_rpi.cpp
@@ -308,6 +308,8 @@ static BYTE getKey(int count)
                 }
                 break;
 
+            case 0x5a: return KEY_SHIFT_TAB;
+
             case 0x5b:
                 c = getchar();
                 switch(c) {

--- a/ce_main_app/config/configstream.h
+++ b/ce_main_app/config/configstream.h
@@ -126,6 +126,10 @@ public:
     void enterKeyHandlerLater(int event);
 
     void setTranslatedDisk(TranslatedDisk *td) { this->translated = td; };
+
+    DWORD getLastCmdTimestamp() const {
+        return lastCmdTime;
+    }
 private:
     // properties
     int shownOn;
@@ -151,6 +155,8 @@ private:
     bool showingHomeScreen;
     bool showingMessage;
     bool screenChanged;
+
+    DWORD lastCmdTime;
 
     void enterKeyHandler(int event);
     

--- a/ce_main_app/config/configstream_general.cpp
+++ b/ce_main_app/config/configstream_general.cpp
@@ -9,6 +9,7 @@
 #include "../translated/translateddisk.h"
 
 #include "../settings.h"
+#include "../utils.h"
 #include "keys.h"
 #include "configstream.h"
 #include "config_commands.h"
@@ -29,6 +30,8 @@ ConfigStream::ConfigStream(int whereItWillBeShown)
 
     dataTrans   = NULL;
     reloadProxy = NULL;
+
+    lastCmdTime = 0;
 
     message.clear();
     createScreen_homeScreen();
@@ -60,6 +63,8 @@ void ConfigStream::processCommand(BYTE *cmd, int writeToFd)
     }
 
     dataTrans->clear();                 // clean data transporter before handling
+
+    lastCmdTime = Utils::getCurrentMs();
 
     switch(cmd[4]) {
     case CFG_CMD_IDENTIFY:          // identify?

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -1235,7 +1235,6 @@ void ConfigStream::createScreen_ikbd(void)
     int col2    = 33;
     
     //-----------
-    row++;
     comp = new ConfigComponent(this, ConfigComponent::label, "Attach 1st joy as JOY 0",     40, col, row, gotoOffset);
     screen.push_back(comp);
     
@@ -1243,9 +1242,12 @@ void ConfigStream::createScreen_ikbd(void)
     comp->setComponentId(COMPID_JOY0_FIRST);
     screen.push_back(comp);
 
+    comp = new ConfigComponent(this, ConfigComponent::label, "(hotkey: CTRL+any SHIFT+HELP/F11)",     40, col, row, gotoOffset);
+    screen.push_back(comp);
+
     //----------------------
 
-    row++;
+    row += 2;
     comp = new ConfigComponent(this, ConfigComponent::label, "Mouse wheel as arrow UP / DOWN", 40, col, row, gotoOffset);
     screen.push_back(comp);
     
@@ -1268,7 +1270,10 @@ void ConfigStream::createScreen_ikbd(void)
     comp->setComponentId(COMPID_KEYB_JOY0);
     screen.push_back(comp);
 
-    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "(hotkey: CTRL+LSHIFT+UNDO/F12)",     40, col, row, gotoOffset);
+    screen.push_back(comp);
+
+    row += 2;
     // button
     comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colButton, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_BUTTON);
@@ -1310,7 +1315,10 @@ void ConfigStream::createScreen_ikbd(void)
     comp->setComponentId(COMPID_KEYB_JOY1);
     screen.push_back(comp);
 
-    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "(hotkey: CTRL+RSHIFT+UNDO/F12)",     40, col, row, gotoOffset);
+    screen.push_back(comp);
+
+    row += 2;
     // button
     comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colButton, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_BUTTON);

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -1255,110 +1255,89 @@ void ConfigStream::createScreen_ikbd(void)
 
     //----------------------
 
-    int col3 = 26;
-    
-    row += 1;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 0 enabled",        40, col, row, gotoOffset);
+    int colButton   = col + 0;
+    int colLeft     = col + 0;
+    int colUpDown   = col + 12;
+    int colRight    = col + 24;
+
+    row += 2;
+    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 0 enabled",         40, col, row, gotoOffset);
     screen.push_back(comp);
-    
-    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                         3, col2, row++, gotoOffset);
+
+    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                          3, col2, row++, gotoOffset);
     comp->setComponentId(COMPID_KEYB_JOY0);
     screen.push_back(comp);
 
+    row++;
     // button
-    comp = new ConfigComponent(this, ConfigComponent::label, "BUTTON:",                       40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",                 10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colButton, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_BUTTON);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
-    
+
     // up
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "UP:",                           40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colUpDown, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_UP);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
-    // left
     row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "LEFT:",                         40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    // left
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colLeft, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_LEFT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // down
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "DOWN:",                         40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colUpDown, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_DOWN);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // right
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "RIGHT:",                        40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colRight, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_RIGHT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     //----------------------
 
-    row += 2;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 1 enabled",       40, col, row, gotoOffset);
+    row += 3;
+    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 1 enabled",         40, col, row, gotoOffset);
     screen.push_back(comp);
-    
-    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                        3, col2, row++, gotoOffset);
+
+    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                          3, col2, row++, gotoOffset);
     comp->setComponentId(COMPID_KEYB_JOY1);
     screen.push_back(comp);
 
+    row++;
     // button
-    comp = new ConfigComponent(this, ConfigComponent::label, "BUTTON:",                       40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colButton, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_BUTTON);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
-    
+
     // up
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "UP:",                           40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colUpDown, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_UP);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
-    // left
     row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "LEFT:",                         40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",                 10, col3, row, gotoOffset);
+    // left
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colLeft, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_LEFT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // down
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "DOWN:",                         40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colUpDown, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_DOWN);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // right
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "RIGHT:",                        40, col, row, gotoOffset);
-    screen.push_back(comp);
-    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, colRight, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_RIGHT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);

--- a/ce_main_app/config/configstream_screens.cpp
+++ b/ce_main_app/config/configstream_screens.cpp
@@ -1255,95 +1255,110 @@ void ConfigStream::createScreen_ikbd(void)
 
     //----------------------
 
-    int colButton   = col + 19;
-    int colLeft     = col + 25;
-    int colUpDown   = col + 29;
-    int colRight    = col + 33;
+    int col3 = 26;
     
-    row += 2;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 0 enabled",         40, col, row, gotoOffset);
+    row += 1;
+    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 0 enabled",        40, col, row, gotoOffset);
     screen.push_back(comp);
     
-    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                          3, col2, row++, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                         3, col2, row++, gotoOffset);
     comp->setComponentId(COMPID_KEYB_JOY0);
     screen.push_back(comp);
 
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keys",                          40, col, row, gotoOffset);
-    screen.push_back(comp);
-
     // button
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colButton, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::label, "BUTTON:",                       40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",                 10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_BUTTON);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
     
     // up
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colUpDown, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "UP:",                           40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_UP);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
-    row++;
     // left
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colLeft, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "LEFT:",                         40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_LEFT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // down
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colUpDown, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "DOWN:",                         40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_DOWN);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // right
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colRight, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "RIGHT:",                        40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY0_RIGHT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     //----------------------
 
-    row += 3;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 1 enabled",         40, col, row, gotoOffset);
+    row += 2;
+    comp = new ConfigComponent(this, ConfigComponent::label, "Keyboard Joy 1 enabled",       40, col, row, gotoOffset);
     screen.push_back(comp);
     
-    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                          3, col2, row++, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::checkbox, "   ",                        3, col2, row++, gotoOffset);
     comp->setComponentId(COMPID_KEYB_JOY1);
     screen.push_back(comp);
 
-    row++;
-    comp = new ConfigComponent(this, ConfigComponent::label, "Keys",                          40, col, row, gotoOffset);
-    screen.push_back(comp);
-
     // button
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colButton, row, gotoOffset);
+    comp = new ConfigComponent(this, ConfigComponent::label, "BUTTON:",                       40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_BUTTON);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
     
     // up
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colUpDown, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "UP:",                           40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_UP);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
-    row++;
     // left
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colLeft, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "LEFT:",                         40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",                 10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_LEFT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // down
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colUpDown, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "DOWN:",                         40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_DOWN);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
 
     // right
-    comp = new ConfigComponent(this, ConfigComponent::editline, " ",	                       1, colRight, row, gotoOffset);
+    row++;
+    comp = new ConfigComponent(this, ConfigComponent::label, "RIGHT:",                        40, col, row, gotoOffset);
+    screen.push_back(comp);
+    comp = new ConfigComponent(this, ConfigComponent::editline, "          ",	              10, col3, row, gotoOffset);
     comp->setComponentId(COMPID_KEYBJOY1_RIGHT);
     comp->setTextOptions(TEXT_OPTION_ALLOW_LETTERS | TEXT_OPTION_LETTERS_ONLY_UPPERCASE);
     screen.push_back(comp);
@@ -1386,37 +1401,37 @@ void ConfigStream::createScreen_ikbd(void)
     keyJoyKeys.setKeyTranslator(&keyTranslator);        // first set the translator
     keyJoyKeys.loadKeys();                              // then load the keys
 
-    std::string joyString = "?";
+    std::string joyString;
 
-    joyString[0] = keyJoyKeys.joyKeys[0].human.button;
+    joyString = keyJoyKeys.joyKeys[0].human.button;
     setTextByComponentId(COMPID_KEYBJOY0_BUTTON, joyString);
     
-    joyString[0] = keyJoyKeys.joyKeys[0].human.left;
+    joyString = keyJoyKeys.joyKeys[0].human.left;
     setTextByComponentId(COMPID_KEYBJOY0_LEFT, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[0].human.right;
+    joyString = keyJoyKeys.joyKeys[0].human.right;
     setTextByComponentId(COMPID_KEYBJOY0_RIGHT, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[0].human.up;
+    joyString = keyJoyKeys.joyKeys[0].human.up;
     setTextByComponentId(COMPID_KEYBJOY0_UP, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[0].human.down;
+    joyString = keyJoyKeys.joyKeys[0].human.down;
     setTextByComponentId(COMPID_KEYBJOY0_DOWN, joyString);
 
     //----------
-    joyString[0] = keyJoyKeys.joyKeys[1].human.button;
+    joyString = keyJoyKeys.joyKeys[1].human.button;
     setTextByComponentId(COMPID_KEYBJOY1_BUTTON, joyString);
     
-    joyString[0] = keyJoyKeys.joyKeys[1].human.left;
+    joyString = keyJoyKeys.joyKeys[1].human.left;
     setTextByComponentId(COMPID_KEYBJOY1_LEFT, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[1].human.right;
+    joyString = keyJoyKeys.joyKeys[1].human.right;
     setTextByComponentId(COMPID_KEYBJOY1_RIGHT, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[1].human.up;
+    joyString = keyJoyKeys.joyKeys[1].human.up;
     setTextByComponentId(COMPID_KEYBJOY1_UP, joyString);
 
-    joyString[0] = keyJoyKeys.joyKeys[1].human.down;
+    joyString = keyJoyKeys.joyKeys[1].human.down;
     setTextByComponentId(COMPID_KEYBJOY1_DOWN, joyString);
     //------------------------
     
@@ -1440,41 +1455,41 @@ void ConfigStream::onIkbdSave(void)
     keyJoyKeys.setKeyTranslator(&keyTranslator);        // first set the translator
     keyJoyKeys.loadKeys();                              // then load the keys
 
-    std::string joyString = "?";
+    std::string joyString;
 
     //----------
     // get settings for joy 0 
     getTextByComponentId(COMPID_KEYBJOY0_BUTTON, joyString);
-    keyJoyKeys.joyKeys[0].human.button = joyString[0];
+    keyJoyKeys.joyKeys[0].human.button = joyString;
     
     getTextByComponentId(COMPID_KEYBJOY0_LEFT, joyString);
-    keyJoyKeys.joyKeys[0].human.left = joyString[0];
+    keyJoyKeys.joyKeys[0].human.left = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY0_RIGHT, joyString);
-    keyJoyKeys.joyKeys[0].human.right = joyString[0];
+    keyJoyKeys.joyKeys[0].human.right = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY0_UP, joyString);
-    keyJoyKeys.joyKeys[0].human.up = joyString[0];
+    keyJoyKeys.joyKeys[0].human.up = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY0_DOWN, joyString);
-    keyJoyKeys.joyKeys[0].human.down = joyString[0];
+    keyJoyKeys.joyKeys[0].human.down = joyString;
 
     //----------
     // get settings for joy 1
     getTextByComponentId(COMPID_KEYBJOY1_BUTTON, joyString);
-    keyJoyKeys.joyKeys[1].human.button = joyString[0];
+    keyJoyKeys.joyKeys[1].human.button = joyString;
     
     getTextByComponentId(COMPID_KEYBJOY1_LEFT, joyString);
-    keyJoyKeys.joyKeys[1].human.left = joyString[0];
+    keyJoyKeys.joyKeys[1].human.left = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY1_RIGHT, joyString);
-    keyJoyKeys.joyKeys[1].human.right = joyString[0];
+    keyJoyKeys.joyKeys[1].human.right = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY1_UP, joyString);
-    keyJoyKeys.joyKeys[1].human.up = joyString[0];
+    keyJoyKeys.joyKeys[1].human.up = joyString;
 
     getTextByComponentId(COMPID_KEYBJOY1_DOWN, joyString);
-    keyJoyKeys.joyKeys[1].human.down = joyString[0];
+    keyJoyKeys.joyKeys[1].human.down = joyString;
     
     //----------
     // validate new settings

--- a/ce_main_app/config/keys.h
+++ b/ce_main_app/config/keys.h
@@ -27,3 +27,4 @@
 #define		KEY_F9		158
 #define		KEY_F10		159
 
+#define     KEY_SHIFT_TAB 160

--- a/ce_main_app/ikbd/ikbd.h
+++ b/ce_main_app/ikbd/ikbd.h
@@ -77,7 +77,7 @@ public:
     void deinitDev(int index);
 
     void processMouse(input_event *ev);
-    void processKeyboard(input_event *ev);
+    void processKeyboard(input_event *ev, bool skipKeyboardTranslation);
     void processJoystick(js_event *jse, int joyNumber);
     void markVirtualMouseEvenTime(void);
 
@@ -92,7 +92,7 @@ private:
         Enabled // joy1 and joy0 are treated as joysticks
     };
 
-    int        ceIkbdMode;
+    int     ceIkbdMode;
 
     bool    outputEnabled;
 
@@ -109,8 +109,14 @@ private:
     bool    keybJoy0;                       // if true, specific keys will act as joy 0
     bool    keybJoy1;                       // if true, specific keys will act as joy 1
 
-    int     shiftsPressed;  // how many SHIFTs are pressed (2x for each keyboard)
-    int     ctrlsPressed;   // how many C[ON]TR[O]Ls are pressed (2x for PC, 1x for Atari)
+    // this is basically all keys which are used for the hotswap, perhaps
+    // it should be made a bit more flexible, for different key combinations
+    int     leftShiftsPressed;  // how many LEFT SHIFTs are pressed (1x for PC, 1x for Atari)
+    int     rightShiftsPressed; // how many RIGHT SHIFTs are pressed (1x for PC, 1x for Atari)
+    int     ctrlsPressed;       // how many C[ON]TR[O]Ls are pressed (2x for PC, 1x for Atari)
+    int     f11sPressed;        // HELP on Atari, F11 on PC
+    int     f12sPressed;        // UNDO on Atari, F12 on PC
+    bool    waitingForHotkeyRelease;
 
     KeybJoyKeys     keyJoyKeys;
     KeyTranslator   keyTranslator;
@@ -178,7 +184,7 @@ private:
     void handlePcKeyAsKeybJoy(int joyNumber, int pcKey, int eventValue);
     bool handleStKeyAsKeybJoy(BYTE val);
     void handleKeyAsKeybJoy  (bool pcNotSt, int joyNumber, int pcKey, bool keyDown);
-    bool handleSpecialHotkeys(int pcKey, int stKey);
+    bool handleHotkeys(int pcKey, bool pressed, bool skipKeyboardTranslation);
 
     int fdWrite(int fd, BYTE *bfr, int cnt);
 

--- a/ce_main_app/ikbd/ikbd.h
+++ b/ce_main_app/ikbd/ikbd.h
@@ -105,6 +105,7 @@ private:
     int     joy1st;
     int     joy2nd;
 
+    bool    firstJoyIs0;                    // if true, joystick keyboard mapping and usb/atari joysticks are swapped
     bool    mouseWheelAsArrowsUpDown;       // if true, mouse wheel up / down will be translated to arrow up / down
     bool    keybJoy0;                       // if true, specific keys will act as joy 0
     bool    keybJoy1;                       // if true, specific keys will act as joy 1

--- a/ce_main_app/ikbd/ikbd.h
+++ b/ce_main_app/ikbd/ikbd.h
@@ -81,7 +81,7 @@ public:
     void processJoystick(js_event *jse, int joyNumber);
     void markVirtualMouseEvenTime(void);
 
-    void processReceivedCommands(void);
+    void processReceivedCommands(bool skipKeyboardTranslation);
 
     int     fdUart;
 
@@ -166,7 +166,7 @@ private:
 
     void processStCommands(void);
     void processGetCommand(BYTE getCmd);
-    void processKeyboardData(void);
+    void processKeyboardData(bool skipKeyboardTranslation);
 
     bool gotUsbMouse(void);
     bool gotUsbJoy1(void);

--- a/ce_main_app/ikbd/ikbd.h
+++ b/ce_main_app/ikbd/ikbd.h
@@ -109,6 +109,9 @@ private:
     bool    keybJoy0;                       // if true, specific keys will act as joy 0
     bool    keybJoy1;                       // if true, specific keys will act as joy 1
 
+    int     shiftsPressed;  // how many SHIFTs are pressed (2x for each keyboard)
+    int     ctrlsPressed;   // how many C[ON]TR[O]Ls are pressed (2x for PC, 1x for Atari)
+
     KeybJoyKeys     keyJoyKeys;
     KeyTranslator   keyTranslator;
 
@@ -175,6 +178,7 @@ private:
     void handlePcKeyAsKeybJoy(int joyNumber, int pcKey, int eventValue);
     bool handleStKeyAsKeybJoy(BYTE val);
     void handleKeyAsKeybJoy  (bool pcNotSt, int joyNumber, int pcKey, bool keyDown);
+    bool handleSpecialHotkeys(int pcKey, int stKey);
 
     int fdWrite(int fd, BYTE *bfr, int cnt);
 

--- a/ce_main_app/ikbd/ikbd.h
+++ b/ce_main_app/ikbd/ikbd.h
@@ -86,6 +86,12 @@ public:
     int     fdUart;
 
 private:
+    enum JoystickState {
+        Disabled,
+        EnabledInMouseMode, // joy1 direction works but its button is mapped as mouse; joy0 is treated as mouse
+        Enabled // joy1 and joy0 are treated as joysticks
+    };
+
     int        ceIkbdMode;
 
     bool    outputEnabled;
@@ -126,7 +132,7 @@ private:
 
     int             joystickMode;
     TJoystickState  joystick[2];
-    bool            joystickEnabled;
+    JoystickState   joystickState;
 
     CyclicBuff      cbStCommands;
     CyclicBuff      cbKeyboardData;
@@ -151,7 +157,7 @@ private:
     void processFoundDev(const char *linkName, const char *fullPath);
 
     void resetInternalIkbdVars(void);
-    void sendJoy0State(void);
+    void sendJoyButtonsInMouseMode(void);
     void sendJoyState(int joyNumber, int dirTotal);
     void sendBothJoyReport(void);
     void sendMousePosRelative(int fd, BYTE buttons, BYTE xRel, BYTE yRel);

--- a/ce_main_app/ikbd/ikbd_defs.h
+++ b/ce_main_app/ikbd/ikbd_defs.h
@@ -29,6 +29,8 @@
 
 #define JOYMODE_EVENT               0x14
 #define JOYMODE_INTERROGATION       0x15
+#define JOYMODE_MONITORING          0x17
+#define JOYMODE_FIRE_MONITORING     0x18
 #define JOYMODE_KEYCODE			    0x19
 
 #define MOUSEABS_BTN_LEFT_UP		8

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -176,7 +176,7 @@ void *ikbdThreadCode(void *ptr)
                         break;
                     case INTYPE_KEYBOARD:
                     case INTYPE_VDEVKEYBOARD:
-                        ikbd.processKeyboard(&ev);
+                        ikbd.processKeyboard(&ev, shared.clientConnected);
                         break;
                     case INTYPE_JOYSTICK1:
                     case INTYPE_JOYSTICK2:
@@ -217,9 +217,6 @@ Ikbd::Ikbd()
 
     gotHalfPair     = false;
     halfPairData    = 0;
-
-    shiftsPressed = 0;
-    ctrlsPressed  = 0;
 
     fillSpecialCodeLengthTable();
     fillStCommandsLengthTable();
@@ -276,6 +273,13 @@ void Ikbd::resetInternalIkbdVars(void)
 
     joystickMode    = JOYMODE_EVENT;
     joystickState   = EnabledInMouseMode;
+
+    leftShiftsPressed  = 0;
+    rightShiftsPressed = 0;
+    ctrlsPressed       = 0;
+    f11sPressed        = 0;
+    f12sPressed        = 0;
+    waitingForHotkeyRelease = false;
 }
 
 int Ikbd::serialSetup(termios *ts)

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -227,7 +227,7 @@ Ikbd::Ikbd()
 void Ikbd::loadSettings(void)
 {
     Settings s;
-    bool firstJoyIs0 = s.getBool((char *) "JOY_FIRST_IS_0", false);
+    firstJoyIs0 = s.getBool((char *) "JOY_FIRST_IS_0", false);
 
     if(firstJoyIs0) {
         joy1st = INTYPE_JOYSTICK1;

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -270,7 +270,7 @@ void Ikbd::resetInternalIkbdVars(void)
     keycodeMouse.deltaY    = 0;
 
     joystickMode    = JOYMODE_EVENT;
-    joystickEnabled = true;
+    joystickState   = EnabledInMouseMode;
 }
 
 int Ikbd::serialSetup(termios *ts)

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -21,6 +21,7 @@
 #include "utils.h"
 #include "settings.h"
 #include "datatypes.h"
+#include "periodicthread.h"
 
 #include "ikbd.h"
 
@@ -30,6 +31,7 @@ extern volatile sig_atomic_t    sigintReceived;
        volatile bool            do_loadIkbdConfig = false;
 
 extern TFlags flags;                                // global flags from command line
+extern SharedObjects shared;
 
 void *ikbdThreadCode(void *ptr)
 {
@@ -134,7 +136,7 @@ void *ikbdThreadCode(void *ptr)
 
         if(ikbd.fdUart >= 0 && FD_ISSET(ikbd.fdUart, &readfds)) {
             // process the incomming data from original keyboard and from ST
-            ikbd.processReceivedCommands();
+            ikbd.processReceivedCommands(shared.clientConnected);
         }
 
         // process events from attached input devices

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -218,6 +218,9 @@ Ikbd::Ikbd()
     gotHalfPair     = false;
     halfPairData    = 0;
 
+    shiftsPressed = 0;
+    ctrlsPressed  = 0;
+
     fillSpecialCodeLengthTable();
     fillStCommandsLengthTable();
 

--- a/ce_main_app/ikbd/ikbd_general.cpp
+++ b/ce_main_app/ikbd/ikbd_general.cpp
@@ -227,7 +227,7 @@ Ikbd::Ikbd()
 void Ikbd::loadSettings(void)
 {
     Settings s;
-    firstJoyIs0 = s.getBool((char *) "JOY_FIRST_IS_0", false);
+    firstJoyIs0 = s.getBool("JOY_FIRST_IS_0", false);
 
     if(firstJoyIs0) {
         joy1st = INTYPE_JOYSTICK1;
@@ -238,7 +238,7 @@ void Ikbd::loadSettings(void)
     }
 
     // get enabled flags for mouse wheel as keys
-    mouseWheelAsArrowsUpDown = s.getBool((char *) "MOUSE_WHEEL_AS_KEYS", true);
+    mouseWheelAsArrowsUpDown = s.getBool("MOUSE_WHEEL_AS_KEYS", true);
 
     // get enabled flags for keyb joys
     keybJoy0 = s.getBool("KEYBORD_JOY0", false);

--- a/ce_main_app/ikbd/ikbd_st.cpp
+++ b/ce_main_app/ikbd/ikbd_st.cpp
@@ -589,13 +589,12 @@ void Ikbd::processKeyboardData(bool skipKeyboardTranslation)
             bool wasHandled = false;                       // it wasn't handled as keyb joy (yet)
 
             int pcKey = keyTranslator.stKeyToPc(val & 0x7f);
-            wasHandled = handleSpecialHotkeys(pcKey, val);
-            
-            if(!wasHandled && !skipKeyboardTranslation
-                    && (keybJoy0 || keybJoy1)) {           // if at least one keyboard joy is enabled
+            skipKeyboardTranslation = handleHotkeys(pcKey, !(val & 0x80), skipKeyboardTranslation);
+
+            if (!skipKeyboardTranslation && !wasHandled) {
                 wasHandled = handleStKeyAsKeybJoy(val);    // get if it was handled as keyb joy
             }
-            
+
             if(!wasHandled) {                              // if not handled as keyb joy, send it to ST
                 fdWrite(fdUart, &val, 1);                           // send byte to ST
             }

--- a/ce_main_app/ikbd/ikbd_st.cpp
+++ b/ce_main_app/ikbd/ikbd_st.cpp
@@ -11,7 +11,7 @@
 
 #include "ikbd.h"
 
-void Ikbd::processReceivedCommands(void)
+void Ikbd::processReceivedCommands(bool skipKeyboardTranslation)
 {
     if(fdUart == -1) {                                          // uart not open? quit
         return;
@@ -60,7 +60,7 @@ void Ikbd::processReceivedCommands(void)
         }
 
         if(cbKeyboardData.count > 0) {                          // got keyboard data? process them
-            processKeyboardData();
+            processKeyboardData(skipKeyboardTranslation);
         }
     #else                                                       // if spying on IKBD, just resend data
         if(cbStCommands.count > 0) {                            // got ST commands? process them
@@ -502,7 +502,7 @@ void Ikbd::fixAbsMousePos(void)
     }
 }
 
-void Ikbd::processKeyboardData(void)
+void Ikbd::processKeyboardData(bool skipKeyboardTranslation)
 {
     BYTE bfr[128];
 
@@ -588,7 +588,7 @@ void Ikbd::processKeyboardData(void)
             val = cbKeyboardData.get();                             // get data from buffer
             bool wasHandledAsKeybJoy = false;                       // it wasn't handled as keyb joy (yet)
             
-            if(keybJoy0 || keybJoy1) {                              // if at least one keyboard joy is enabled
+            if(!skipKeyboardTranslation && (keybJoy0 || keybJoy1)) {// if at least one keyboard joy is enabled
                 wasHandledAsKeybJoy = handleStKeyAsKeybJoy(val);    // get if it was handled as keyb joy
             }
             

--- a/ce_main_app/ikbd/ikbd_st.cpp
+++ b/ce_main_app/ikbd/ikbd_st.cpp
@@ -769,13 +769,8 @@ bool Ikbd::handleStKeyAsKeybJoy(BYTE val)
     }
 
     int joyNumber = isKeybJoy0 ? 0 : 1;         // if it's from joy 0, then joy # is 0, otherwise 1
-    int pcKey = keyTranslator.stKeyToPc(stKey); // translate ST key to PC key
 
-    if(pcKey == 0) {                            // failed to translate ST key to PC key? fail
-        return false;
-    }
-
-    handleKeyAsKeybJoy(false, joyNumber, pcKey, keyDown);   // handle this key press, and it comes from ST keys (therefore first param: false)
+    handleKeyAsKeybJoy(false, joyNumber, stKey, keyDown);   // handle this key press, and it comes from ST keys (therefore first param: false)
     return true;
 }
 

--- a/ce_main_app/ikbd/ikbd_st.cpp
+++ b/ce_main_app/ikbd/ikbd_st.cpp
@@ -586,13 +586,17 @@ void Ikbd::processKeyboardData(bool skipKeyboardTranslation)
 			continue;
         } else {                                                    // if it's not special IKBD code, then it's just a key press
             val = cbKeyboardData.get();                             // get data from buffer
-            bool wasHandledAsKeybJoy = false;                       // it wasn't handled as keyb joy (yet)
+            bool wasHandled = false;                       // it wasn't handled as keyb joy (yet)
+
+            int pcKey = keyTranslator.stKeyToPc(val & 0x7f);
+            wasHandled = handleSpecialHotkeys(pcKey, val);
             
-            if(!skipKeyboardTranslation && (keybJoy0 || keybJoy1)) {// if at least one keyboard joy is enabled
-                wasHandledAsKeybJoy = handleStKeyAsKeybJoy(val);    // get if it was handled as keyb joy
+            if(!wasHandled && !skipKeyboardTranslation
+                    && (keybJoy0 || keybJoy1)) {           // if at least one keyboard joy is enabled
+                wasHandled = handleStKeyAsKeybJoy(val);    // get if it was handled as keyb joy
             }
             
-            if(!wasHandledAsKeybJoy) {                              // if not handled as keyb joy, send it to ST
+            if(!wasHandled) {                              // if not handled as keyb joy, send it to ST
                 fdWrite(fdUart, &val, 1);                           // send byte to ST
             }
         }

--- a/ce_main_app/ikbd/ikbd_usb.cpp
+++ b/ce_main_app/ikbd/ikbd_usb.cpp
@@ -539,8 +539,8 @@ void Ikbd::processJoystick(js_event *jse, int joyNumber)
         js->lastDir = dirTotal;
         js->lastBtn = button;
 
-        if(joyNumber == 1 && (mouseMode == MOUSEMODE_REL) && btnChanged) {  // if button state changed, send it as mouse packet
-            sendJoy0State();
+        if(joystickState == EnabledInMouseMode && btnChanged) {  // if button state changed, send it as mouse packet
+            sendJoyButtonsInMouseMode();
         } else {
             sendJoyState(joyNumber, button | dirTotal);                        // report current direction and buttons
         }

--- a/ce_main_app/ikbd/ikbd_usb.cpp
+++ b/ce_main_app/ikbd/ikbd_usb.cpp
@@ -414,19 +414,23 @@ void Ikbd::processKeyboard(input_event *ev, bool skipKeyboardTranslation)
         statuses.ikbdUsb.aliveTime = Utils::getCurrentMs();
         statuses.ikbdUsb.aliveSign = ALIVE_KEYDOWN;
 
+        if(ev->code >= KBD_KEY_COUNT) {
+            return;
+        }
+
         stKey = keyTranslator.pcKeyToSt(ev->code);          // translate PC key to ST key
         // ev->value -- 1: down, 2: auto repeat, 0: up
         if(ev->value == 0) {        // when key is released, ST scan code has the highest bit set
             stKey = stKey | 0x80;
             pressedKeys[ev->code] = false;
+        } else if (ev->value == 1) {
+            pressedKeys[ev->code] = true;
+            if(pressedKeys[KEY_LEFTCTRL] && pressedKeys[KEY_RIGHTCTRL] && pressedKeys[KEY_LEFTALT] && pressedKeys[KEY_RIGHTALT]) {
+                toggleKeyboardExclusiveAccess();
+            }
         } else if (ev->value == 2) {
             // auto repeat has no place on Atari! :)
             return;
-        }
-
-        pressedKeys[ev->code] = true;
-        if(pressedKeys[KEY_LEFTCTRL] && pressedKeys[KEY_RIGHTCTRL] && pressedKeys[KEY_LEFTALT] && pressedKeys[KEY_RIGHTALT]) {
-            toggleKeyboardExclusiveAccess();
         }
 
         if(stKey == 0 || stKey == 0x80 || fdUart == -1) {           // key not found, no UART open? quit

--- a/ce_main_app/ikbd/ikbd_usb.cpp
+++ b/ce_main_app/ikbd/ikbd_usb.cpp
@@ -712,8 +712,17 @@ bool Ikbd::handleHotkeys(int pcKey, bool pressed, bool skipKeyboardTranslation)
     if ((leftShiftsPressed > 0 || rightShiftsPressed > 0) && ctrlsPressed > 0 && pressed) {
         Settings s;
         if (f11sPressed > 0) {
-            // TODO: toggle joy0 / joy1 (done on USB, missing on ST!)
-            ikbdLog( "Ikbd::handleHotkeys - toggle joy0 / joy1");
+            firstJoyIs0 = !firstJoyIs0;
+            s.setBool("JOY_FIRST_IS_0", firstJoyIs0);
+            if(firstJoyIs0) {
+                joy1st = INTYPE_JOYSTICK1;
+                joy2nd = INTYPE_JOYSTICK2;
+            } else {
+                joy1st = INTYPE_JOYSTICK2;
+                joy2nd = INTYPE_JOYSTICK1;
+            }
+            ikbdLog( "Ikbd::handleHotkeys - joy0 <-> joy1 [before: %s, now: %s]",
+                     firstJoyIs0 ? "OFF" : "ON", firstJoyIs0 ? "ON" : "OFF");
         } else if (f12sPressed > 0) {
             if (leftShiftsPressed > 0) {
                 keybJoy0 = !keybJoy0;

--- a/ce_main_app/ikbd/ikbd_usb.cpp
+++ b/ce_main_app/ikbd/ikbd_usb.cpp
@@ -414,7 +414,7 @@ void Ikbd::processKeyboard(input_event *ev, bool skipKeyboardTranslation)
         statuses.ikbdUsb.aliveTime = Utils::getCurrentMs();
         statuses.ikbdUsb.aliveSign = ALIVE_KEYDOWN;
 
-        int stKey = keyTranslator.pcKeyToSt(ev->code);          // translate PC key to ST key
+        stKey = keyTranslator.pcKeyToSt(ev->code);          // translate PC key to ST key
         // ev->value -- 1: down, 2: auto repeat, 0: up
         if(ev->value == 0) {        // when key is released, ST scan code has the highest bit set
             stKey = stKey | 0x80;

--- a/ce_main_app/ikbd/ikbd_usb.cpp
+++ b/ce_main_app/ikbd/ikbd_usb.cpp
@@ -407,10 +407,10 @@ void Ikbd::processKeyboard(input_event *ev, bool skipKeyboardTranslation)
 
     switch(ev->type) {
     case EV_SYN:
-        ikbdLog("Ikbd::processKeyboard() EV_SYN code=%04x\n", ev->code);
+        //ikbdLog("Ikbd::processKeyboard() EV_SYN code=%04x\n", ev->code);
         break;
     case EV_KEY:
-        ikbdLog("Ikbd::processKeyboard() EV_KEY code=%04x ev->value=%d\n", ev->code, ev->value);
+        //ikbdLog("Ikbd::processKeyboard() EV_KEY code=%04x ev->value=%d\n", ev->code, ev->value);
         statuses.ikbdUsb.aliveTime = Utils::getCurrentMs();
         statuses.ikbdUsb.aliveSign = ALIVE_KEYDOWN;
 
@@ -458,7 +458,7 @@ void Ikbd::processKeyboard(input_event *ev, bool skipKeyboardTranslation)
         }
         break;
     case EV_MSC:
-        ikbdLog("Ikbd::processKeyboard() EV_MSC code=%d value=0x%08x\n", ev->code, ev->value);
+        //ikbdLog("Ikbd::processKeyboard() EV_MSC code=%d value=0x%08x\n", ev->code, ev->value);
         break;
     default:
         logDebugAndIkbd(LOG_DEBUG, "Ikbd::processKeyboard() ***UNKNOWN*** ev->type=%d ev->code=0x%04x ev->value=0x%08x\n", ev->type, ev->code, ev->value);

--- a/ce_main_app/ikbd/keybjoys.h
+++ b/ce_main_app/ikbd/keybjoys.h
@@ -1,6 +1,8 @@
 #ifndef _KEYBJOYS_H_
 #define _KEYBJOYS_H_
 
+#include <string>
+
 #include "keytranslator.h"
 
 typedef struct {
@@ -12,9 +14,17 @@ typedef struct {
 } JoyKeys;
 
 typedef struct {
-    JoyKeys human;             // human readable keys, e.g. 'A' 
-    JoyKeys linuxx;            // linux key event codes, like KEY_A
-    JoyKeys atari;             // atari key codes, like 0x1e
+    std::string up;
+    std::string down;
+    std::string left;
+    std::string right;
+    std::string button;
+} JoyKeysHuman;
+
+typedef struct {
+    JoyKeysHuman human;             // human readable keys, e.g. "A" or "LCTRL"
+    JoyKeys      linuxx;            // linux key event codes, like KEY_A
+    JoyKeys      atari;             // atari key codes, like 0x1e
 } JoyKeysPcSt;
 
 class KeybJoyKeys {

--- a/ce_main_app/ikbd/keytranslator.cpp
+++ b/ce_main_app/ikbd/keytranslator.cpp
@@ -191,7 +191,7 @@ int KeyTranslator::stKeyToPc(int stKey) const
     int i;
     for(i=0; i<KEY_TABLE_SIZE; i++) {               // go through pcToSt table, and find which pcKey (index) matches the st key, and return it
         if(tableKeysPcToSt[i] == stKey) {
-            return i;
+            return tableKeysPcToSt[i];
         }
     }
     

--- a/ce_main_app/ikbd/keytranslator.cpp
+++ b/ce_main_app/ikbd/keytranslator.cpp
@@ -10,109 +10,123 @@ KeyTranslator::KeyTranslator(void)
 
 void KeyTranslator::fillKeyTranslationTable(void)
 {
-    memset(tableKeysPcToSt,     0, sizeof(tableKeysPcToSt));
-    memset(tableKeysPcToHuman,  0, sizeof(tableKeysPcToHuman));
+    memset(tableKeysPcToSt, 0, sizeof(tableKeysPcToSt));
     
-    addToTable(KEY_ESC,         0x01);
-    addToTable(KEY_1,           0x02, '1');
-    addToTable(KEY_2,           0x03, '2');
-    addToTable(KEY_3,           0x04, '3');
-    addToTable(KEY_4,           0x05, '4');
-    addToTable(KEY_5,           0x06, '5');
-    addToTable(KEY_6,           0x07, '6');
-    addToTable(KEY_7,           0x08, '7');
-    addToTable(KEY_8,           0x09, '8');
-    addToTable(KEY_9,           0x0a, '9');
-    addToTable(KEY_0,           0x0b, '0');
-    addToTable(KEY_MINUS,       0x0c, '-');
-    addToTable(KEY_EQUAL,       0x0d, '=');
-    addToTable(KEY_BACKSPACE,   0x0e);
-    addToTable(KEY_TAB,         0x0f);
-    addToTable(KEY_Q,           0x10, 'Q');
-    addToTable(KEY_W,           0x11, 'W');
-    addToTable(KEY_E,           0x12, 'E');
-    addToTable(KEY_R,           0x13, 'R');
-    addToTable(KEY_T,           0x14, 'T');
-    addToTable(KEY_Y,           0x15, 'Y');
-    addToTable(KEY_U,           0x16, 'U');
-    addToTable(KEY_I,           0x17, 'I');
-    addToTable(KEY_O,           0x18, 'O');
-    addToTable(KEY_P,           0x19, 'P');
-    addToTable(KEY_LEFTBRACE,   0x1a, '(');
-    addToTable(KEY_RIGHTBRACE,  0x1b, ')');
-    addToTable(KEY_ENTER,       0x1c);
-    addToTable(KEY_LEFTCTRL,    0x1d);
-    addToTable(KEY_A,           0x1e, 'A');
-    addToTable(KEY_S,           0x1f, 'S');
-    addToTable(KEY_D,           0x20, 'D');
-    addToTable(KEY_F,           0x21, 'F');
-    addToTable(KEY_G,           0x22, 'G');
-    addToTable(KEY_H,           0x23, 'H');
-    addToTable(KEY_J,           0x24, 'J');
-    addToTable(KEY_K,           0x25, 'K');
-    addToTable(KEY_L,           0x26, 'L');
-    addToTable(KEY_SEMICOLON,   0x27, ';');
-    addToTable(KEY_APOSTROPHE,  0x28, '\'');
-    addToTable(KEY_GRAVE,       0x2b);
-    addToTable(KEY_LEFTSHIFT,   0x2a);
-    addToTable(KEY_BACKSLASH,   0x60, '\\');
-    addToTable(KEY_Z,           0x2c, 'Z');
-    addToTable(KEY_X,           0x2d, 'X');
-    addToTable(KEY_C,           0x2e, 'C');
-    addToTable(KEY_V,           0x2f, 'V');
-    addToTable(KEY_B,           0x30, 'B');
-    addToTable(KEY_N,           0x31, 'N');
-    addToTable(KEY_M,           0x32, 'M');
-    addToTable(KEY_COMMA,       0x33, ',');
-    addToTable(KEY_DOT,         0x34, '.');
-    addToTable(KEY_SLASH,       0x35, '/');
-    addToTable(KEY_RIGHTSHIFT,  0x36);
-    addToTable(KEY_KPASTERISK,  0x66, '*');
-    addToTable(KEY_LEFTALT,     0x38);
-    addToTable(KEY_SPACE,       0x39, ' ');
-    addToTable(KEY_CAPSLOCK,    0x3a);
-    addToTable(KEY_F1,          0x3b);
-    addToTable(KEY_F2,          0x3c);
-    addToTable(KEY_F3,          0x3d);
-    addToTable(KEY_F4,          0x3e);
-    addToTable(KEY_F5,          0x3f);
-    addToTable(KEY_F6,          0x40);
-    addToTable(KEY_F7,          0x41);
-    addToTable(KEY_F8,          0x42);
-    addToTable(KEY_F9,          0x43);
-    addToTable(KEY_F10,         0x44);
-    addToTable(KEY_KP7,         0x67);
-    addToTable(KEY_KP8,         0x68);
-    addToTable(KEY_KP9,         0x69);
-    addToTable(KEY_KPMINUS,     0x4a, '-');
-    addToTable(KEY_KP4,         0x6a);
-    addToTable(KEY_KP5,         0x6b);
-    addToTable(KEY_KP6,         0x6c);
-    addToTable(KEY_KPPLUS,      0x4e, '+');
-    addToTable(KEY_KP1,         0x6d);
-    addToTable(KEY_KP2,         0x6e);
-    addToTable(KEY_KP3,         0x6f);
-    addToTable(KEY_KP0,         0x70);
-    addToTable(KEY_KPDOT,       0x71, '.');
-    addToTable(KEY_KPENTER,     0x72);
-    addToTable(KEY_RIGHTCTRL,   0x1d);
-    addToTable(KEY_KPSLASH,     0x65, '/');
-    addToTable(KEY_RIGHTALT,    0x38);
-    addToTable(KEY_UP,          0x48);
-    addToTable(KEY_LEFT,        0x4b);
-    addToTable(KEY_RIGHT,       0x4d);
-    addToTable(KEY_DOWN,        0x50);
-    addToTable(KEY_HOME,        0x62);
-    addToTable(KEY_PAGEUP,      0x61);
-    addToTable(KEY_PAGEDOWN,    0x47);
-    addToTable(KEY_INSERT,      0x52);
-    addToTable(KEY_DELETE,      0x53);
+    addToTable(KEY_ESC,         0x01, "ESC");
+    addToTable(KEY_1,           0x02, "1");
+    addToTable(KEY_2,           0x03, "2");
+    addToTable(KEY_3,           0x04, "3");
+    addToTable(KEY_4,           0x05, "4");
+    addToTable(KEY_5,           0x06, "5");
+    addToTable(KEY_6,           0x07, "6");
+    addToTable(KEY_7,           0x08, "7");
+    addToTable(KEY_8,           0x09, "8");
+    addToTable(KEY_9,           0x0a, "9");
+    addToTable(KEY_0,           0x0b, "0");
+    addToTable(KEY_MINUS,       0x0c, "-");
+    addToTable(KEY_EQUAL,       0x0d, "=");
+    addToTable(KEY_BACKSPACE,   0x0e, "BACKSPACE");
+    addToTable(KEY_TAB,         0x0f, "TAB");
+    addToTable(KEY_Q,           0x10, "Q");
+    addToTable(KEY_W,           0x11, "W");
+    addToTable(KEY_E,           0x12, "E");
+    addToTable(KEY_R,           0x13, "R");
+    addToTable(KEY_T,           0x14, "T");
+    addToTable(KEY_Y,           0x15, "Y");
+    addToTable(KEY_U,           0x16, "U");
+    addToTable(KEY_I,           0x17, "I");
+    addToTable(KEY_O,           0x18, "O");
+    addToTable(KEY_P,           0x19, "P");
+    addToTable(KEY_LEFTBRACE,   0x1a, "[");
+    addToTable(KEY_RIGHTBRACE,  0x1b, "]");
+    addToTable(KEY_ENTER,       0x1c, "ENTER");
+    addToTable(KEY_LEFTCTRL,    0x1d, "LCTRL");
+    addToTable(KEY_A,           0x1e, "A");
+    addToTable(KEY_S,           0x1f, "S");
+    addToTable(KEY_D,           0x20, "D");
+    addToTable(KEY_F,           0x21, "F");
+    addToTable(KEY_G,           0x22, "G");
+    addToTable(KEY_H,           0x23, "H");
+    addToTable(KEY_J,           0x24, "J");
+    addToTable(KEY_K,           0x25, "K");
+    addToTable(KEY_L,           0x26, "L");
+    addToTable(KEY_SEMICOLON,   0x27, ";");
+    addToTable(KEY_APOSTROPHE,  0x28, "'");
+    addToTable(KEY_GRAVE,       0x2b, "#");
+    addToTable(KEY_LEFTSHIFT,   0x2a, "LSHIFT");
+    addToTable(KEY_BACKSLASH,   0x60, "\\");    // "ISO KEY" on Atari
+    addToTable(KEY_Z,           0x2c, "Z");
+    addToTable(KEY_X,           0x2d, "X");
+    addToTable(KEY_C,           0x2e, "C");
+    addToTable(KEY_V,           0x2f, "V");
+    addToTable(KEY_B,           0x30, "B");
+    addToTable(KEY_N,           0x31, "N");
+    addToTable(KEY_M,           0x32, "M");
+    addToTable(KEY_COMMA,       0x33, ",");
+    addToTable(KEY_DOT,         0x34, ".");
+    addToTable(KEY_SLASH,       0x35, "/");
+    addToTable(KEY_RIGHTSHIFT,  0x36, "RSHIFT");
+    addToTable(KEY_LEFTALT,     0x38, "LALT");
+    addToTable(KEY_SPACE,       0x39, " ");
+    addToTable(KEY_CAPSLOCK,    0x3a, "CAPS");
+    addToTable(KEY_F1,          0x3b, "F1");
+    addToTable(KEY_F2,          0x3c, "F2");
+    addToTable(KEY_F3,          0x3d, "F3");
+    addToTable(KEY_F4,          0x3e, "F4");
+    addToTable(KEY_F5,          0x3f, "F5");
+    addToTable(KEY_F6,          0x40, "F6");
+    addToTable(KEY_F7,          0x41, "F7");
+    addToTable(KEY_F8,          0x42, "F8");
+    addToTable(KEY_F9,          0x43, "F9");
+    addToTable(KEY_F10,         0x44, "F10");
+
+    addToTable(KEY_HOME,        0x47, "HOME");  // 62???
+    addToTable(KEY_UP,          0x48, "UP");
+    addToTable(KEY_KPMINUS,     0x4a, "KPMINUS");
+    addToTable(KEY_LEFT,        0x4b, "LEFT");
+    addToTable(KEY_RIGHT,       0x4d, "RIGHT");
+    addToTable(KEY_KPPLUS,      0x4e, "KPPLUS");
+    addToTable(KEY_DOWN,        0x50, "DOWN");
+    addToTable(KEY_INSERT,      0x52, "INSERT");
+    addToTable(KEY_DELETE,      0x53, "DELETE");
+
+    addToTable(KEY_KPLEFTPAREN, 0x63, "KPLPARENT");
+    addToTable(KEY_KPRIGHTPAREN,0x64, "KPRPARENT");
+    addToTable(KEY_KPSLASH,     0x65, "KPSLASH");
+    addToTable(KEY_KPASTERISK,  0x66, "KPASTERISK");
+    addToTable(KEY_KP7,         0x67, "KP7");
+    addToTable(KEY_KP8,         0x68, "KP8");
+    addToTable(KEY_KP9,         0x69, "KP9");
+    addToTable(KEY_KP4,         0x6a, "KP4");
+    addToTable(KEY_KP5,         0x6b, "KP5");
+    addToTable(KEY_KP6,         0x6c, "KP6");
+    addToTable(KEY_KP1,         0x6d, "KP1");
+    addToTable(KEY_KP2,         0x6e, "KP2");
+    addToTable(KEY_KP3,         0x6f, "KP3");
+    addToTable(KEY_KP0,         0x70, "KP0");
+    addToTable(KEY_KPDOT,       0x71, "KPDOT");
+    addToTable(KEY_KPENTER,     0x72, "KPENTER");
+
+    addToTable(KEY_RIGHTCTRL,   0x1d, "RCTRL");
+    addToTable(KEY_RIGHTALT,    0x38, "RALT");
+    // TODO: where those Atari codes come from?
+    addToTable(KEY_PAGEUP,      0x61, "PAGEUP");
+    addToTable(KEY_PAGEDOWN,    0x47, "PAGEDOWN");
+
+    // TODO: these Atari keys have no equivalent
+    // 61	UNDO
+    // 62	HELP
 }
 
-void KeyTranslator::addToTable(int pcKey, int stKey, int humanKey)
+void KeyTranslator::addToTable(int pcKey, int stKey, const std::string& humanKey)
 {
     if(pcKey >= KEY_TABLE_SIZE) {
         Debug::out(LOG_ERROR, "addToTable -- Can't add pair %d - %d - out of range.", pcKey, stKey);
+        return;
+    }
+
+    if (humanKey.size() > 10) {
+        Debug::out(LOG_ERROR, "addToTable -- Can't add pair %d - %d - %s - human string too big.", pcKey, stKey, humanKey.c_str());
         return;
     }
 
@@ -120,25 +134,26 @@ void KeyTranslator::addToTable(int pcKey, int stKey, int humanKey)
     tableKeysPcToHuman[pcKey]   = humanKey;
 }
 
-int KeyTranslator::pcKeyToSt(int pcKey)
+int KeyTranslator::pcKeyToSt(int pcKey) const
 {
     if(pcKey < 0 || pcKey >= KEY_TABLE_SIZE) {      // invalid / too big key? 
-        return 0;
+        return tableKeysPcToSt[KEY_SPACE];
     }
     
     return tableKeysPcToSt[pcKey];                  // return the key translated through table
 }
 
-int KeyTranslator::pcKeyToHuman(int pcKey)
+const std::string& KeyTranslator::pcKeyToHuman(int pcKey) const
 {
-    if(pcKey < 0 || pcKey >= KEY_TABLE_SIZE) {      // invalid / too big key? 
-        return ' ';
+    if(pcKey < 0 || pcKey >= KEY_TABLE_SIZE) {      // invalid / too big key?
+        return tableKeysPcToHuman[KEY_SPACE];
     }
     
     return tableKeysPcToHuman[pcKey];               // return the key translated through table
 }
 
-int KeyTranslator::humanKeyToPc(int humanKey)
+// TODO: optimize
+int KeyTranslator::humanKeyToPc(const std::string& humanKey) const
 {
     int i;
     for(i=0; i<KEY_TABLE_SIZE; i++) {               // go through pcToHuman table, and find which pcKey (index) matches the human key, and return it
@@ -147,17 +162,18 @@ int KeyTranslator::humanKeyToPc(int humanKey)
         }
     }
     
-    return 0;                                       // not found, return space
+    return KEY_SPACE;                               // not found, return space
 }
 
-int KeyTranslator::humanKeyToSt(int humanKey)
+int KeyTranslator::humanKeyToSt(const std::string& humanKey) const
 {
     int pcKey = humanKeyToPc(humanKey);
     int stKey = tableKeysPcToSt[pcKey];
     return stKey;
 }
 
-int KeyTranslator::stKeyToPc(int stKey)
+// TODO: optimize
+int KeyTranslator::stKeyToPc(int stKey) const
 {
     int i;
     for(i=0; i<KEY_TABLE_SIZE; i++) {               // go through pcToSt table, and find which pcKey (index) matches the st key, and return it
@@ -166,5 +182,5 @@ int KeyTranslator::stKeyToPc(int stKey)
         }
     }
     
-    return 0;
+    return tableKeysPcToSt[KEY_SPACE];
 }

--- a/ce_main_app/ikbd/keytranslator.cpp
+++ b/ce_main_app/ikbd/keytranslator.cpp
@@ -113,6 +113,19 @@ void KeyTranslator::fillKeyTranslationTable(void)
     addToTable(KEY_PAGEUP,      0x61, "PAGEUP");
     addToTable(KEY_PAGEDOWN,    0x47, "PAGEDOWN");
 
+    // TODO: Eiffel keys
+    // SCROLL       $4C
+    // PAGE UP      $45
+    // PAGE DOWN    $46
+    // END          $55
+    // PRINT SCREEN $49
+    // PAUSE        $4F
+    // VERR NUM     $54
+    // LEFT WIN     $56
+    // RIGHT WIN    $57
+    // WIN POPUP    $58
+    // Tilde        $5B
+
     // TODO: these Atari keys have no equivalent
     // 61	UNDO
     // 62	HELP

--- a/ce_main_app/ikbd/keytranslator.cpp
+++ b/ce_main_app/ikbd/keytranslator.cpp
@@ -79,8 +79,10 @@ void KeyTranslator::fillKeyTranslationTable(void)
     addToTable(KEY_F8,          0x42, "F8");
     addToTable(KEY_F9,          0x43, "F9");
     addToTable(KEY_F10,         0x44, "F10");
+    addToTable(KEY_F11,         0x62, "F11");   // HELP
+    addToTable(KEY_F12,         0x61, "F12");   // UNDO
 
-    addToTable(KEY_HOME,        0x47, "HOME");  // 62???
+    addToTable(KEY_HOME,        0x47, "HOME");
     addToTable(KEY_UP,          0x48, "UP");
     addToTable(KEY_KPMINUS,     0x4a, "KPMINUS");
     addToTable(KEY_LEFT,        0x4b, "LEFT");
@@ -109,9 +111,6 @@ void KeyTranslator::fillKeyTranslationTable(void)
 
     addToTable(KEY_RIGHTCTRL,   0x1d, "RCTRL");
     addToTable(KEY_RIGHTALT,    0x38, "RALT");
-    // TODO: where those Atari codes come from?
-    addToTable(KEY_PAGEUP,      0x61, "PAGEUP");
-    addToTable(KEY_PAGEDOWN,    0x47, "PAGEDOWN");
 
     // TODO: Eiffel keys
     // SCROLL       $4C
@@ -126,20 +125,13 @@ void KeyTranslator::fillKeyTranslationTable(void)
     // WIN POPUP    $58
     // Tilde        $5B
 
-    // TODO: these Atari keys have no equivalent
-    // 61	UNDO
-    // 62	HELP
+    // TODO: allow multimaps, i.e. PAGEUP = SHIFT + UP
 }
 
 void KeyTranslator::addToTable(int pcKey, int stKey, const std::string& humanKey)
 {
     if(pcKey >= KEY_TABLE_SIZE) {
         Debug::out(LOG_ERROR, "addToTable -- Can't add pair %d - %d - out of range.", pcKey, stKey);
-        return;
-    }
-
-    if (humanKey.size() > 10) {
-        Debug::out(LOG_ERROR, "addToTable -- Can't add pair %d - %d - %s - human string too big.", pcKey, stKey, humanKey.c_str());
         return;
     }
 
@@ -180,7 +172,13 @@ int KeyTranslator::humanKeyToPc(const std::string& humanKey) const
 
 int KeyTranslator::humanKeyToSt(const std::string& humanKey) const
 {
-    int pcKey = humanKeyToPc(humanKey);
+    std::string humanKeyPatched = humanKey;
+    if (humanKey == "HELP") {
+        humanKeyPatched = "F11";
+    } else if (humanKey == "UNDO") {
+        humanKeyPatched = "F12";
+    }
+    int pcKey = humanKeyToPc(humanKeyPatched);
     int stKey = tableKeysPcToSt[pcKey];
     return stKey;
 }
@@ -191,9 +189,9 @@ int KeyTranslator::stKeyToPc(int stKey) const
     int i;
     for(i=0; i<KEY_TABLE_SIZE; i++) {               // go through pcToSt table, and find which pcKey (index) matches the st key, and return it
         if(tableKeysPcToSt[i] == stKey) {
-            return tableKeysPcToSt[i];
+            return i;
         }
     }
     
-    return tableKeysPcToSt[KEY_SPACE];
+    return KEY_SPACE;
 }

--- a/ce_main_app/ikbd/keytranslator.h
+++ b/ce_main_app/ikbd/keytranslator.h
@@ -1,24 +1,26 @@
 #ifndef _KEYTRANSLATOR_H_
 #define _KEYTRANSLATOR_H_
 
+#include <string>
+
 #define KEY_TABLE_SIZE  256
 
 class KeyTranslator {
-    public:
-        KeyTranslator();
-    
-        int pcKeyToSt       (int pcKey);
-        int pcKeyToHuman    (int pcKey);
-        int humanKeyToPc    (int humanKey);
-        int humanKeyToSt    (int humanKey);
-        int stKeyToPc       (int stKey);
-    
-    private:
-        int  tableKeysPcToSt     [KEY_TABLE_SIZE];
-        int  tableKeysPcToHuman  [KEY_TABLE_SIZE];
+public:
+    KeyTranslator();
 
-        void fillKeyTranslationTable(void);
-        void addToTable(int pcKey, int stKey, int humanKey=0);
+    int pcKeyToSt                   (int pcKey) const;
+    const std::string& pcKeyToHuman (int pcKey) const;
+    int humanKeyToPc                (const std::string& humanKey) const;
+    int humanKeyToSt                (const std::string& humanKey) const;
+    int stKeyToPc                   (int stKey) const;
+
+private:
+    int         tableKeysPcToSt     [KEY_TABLE_SIZE];
+    std::string tableKeysPcToHuman  [KEY_TABLE_SIZE];
+
+    void fillKeyTranslationTable(void);
+    void addToTable(int pcKey, int stKey, const std::string& humanKey);
 };
 
 #endif

--- a/ce_main_app/periodicthread.cpp
+++ b/ce_main_app/periodicthread.cpp
@@ -160,6 +160,10 @@ void *periodicThreadCode(void *ptr)
         }
 
         //------------------------------------
+        // check client command timestamp (we don't really care how often its done)
+        shared.clientConnected = (Utils::getCurrentMs() - shared.configStream.acsi->getLastCmdTimestamp() <= 2000);
+
+        //------------------------------------
         // config streams handling
         
         handleConfigStreams(shared.configStream.web,    shared.configPipes.web.fd1,     shared.configPipes.web.fd2);

--- a/ce_main_app/periodicthread.h
+++ b/ce_main_app/periodicthread.h
@@ -38,6 +38,8 @@ typedef struct {
     
     bool devFinder_detachAndLook;
     bool devFinder_look;
+
+    volatile bool clientConnected;
     
 } SharedObjects;
 

--- a/ce_main_app/utils.cpp
+++ b/ce_main_app/utils.cpp
@@ -1,12 +1,20 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include "utils.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <unistd.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#include <errno.h>
 
 //--------
 // following includes are here for the code for getting IP address of interfaces
@@ -17,10 +25,6 @@
 #include <linux/if_link.h>
 //--------
 
-#include <sstream>
-#include <iostream>
-
-#include "utils.h"
 #include "translated/translatedhelper.h"
 #include "translated/gemdos.h"
 #include "debug.h"
@@ -540,4 +544,12 @@ std::string Utils::getDeviceLabel(const std::string & devicePath)
 		label.replace(pos, 4, 1, (char)c);
 	}
 	return label;
+
+void Utils::splitString(const std::string &s, char delim, std::vector<std::string> &elems) {
+    std::stringstream ss;
+    ss.str(s);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+        elems.push_back(item);
+    }
 }

--- a/ce_main_app/utils.cpp
+++ b/ce_main_app/utils.cpp
@@ -544,6 +544,7 @@ std::string Utils::getDeviceLabel(const std::string & devicePath)
 		label.replace(pos, 4, 1, (char)c);
 	}
 	return label;
+}
 
 void Utils::splitString(const std::string &s, char delim, std::vector<std::string> &elems) {
     std::stringstream ss;

--- a/ce_main_app/utils.h
+++ b/ce_main_app/utils.h
@@ -3,6 +3,7 @@
 
 #include <signal.h>
 #include <string>
+#include <vector>
 
 #include "datatypes.h"
 
@@ -49,6 +50,9 @@ public:
     static void setTimezoneVariable_inThisContext(void);
 
     static std::string getDeviceLabel(const std::string & devicePath);
+
+    static void splitString(const std::string &s, char delim, std::vector<std::string> &elems);
+
 private:
     static bool copyFileByHandles(FILE *from, FILE *to);
 


### PR DESCRIPTION
I'll try to conclude all changes in this PR. Yes, I suck, I should have separated it into small patches.

1. Joystick translation can use generic keycodes, not only alphanumeric (ASCII). Right now you have to type it as following, I've decided not to implement another text field flag which would catch the scan codes directly as this would require major rework of the ST side as well. I've left out Eiffel keycodes as well for now. Namely you can type:
    - BACKSPACE, TAB, ENTER, LCTRL, LSHIFT, RSHIFT, LALT, CAPS, F1~F10, F11 (or HELP), F12 (or UNDO), HOME, UP, LEFT, RIGHT, DOWN, INSERT, DELETE
   - RCTRL, RALT (PC only)
   - KPMINUS, KPPLUS, KPLPARENT, KPRPARENT, KPSLASH, KPASTERISK, KP0~KP9, KPDOT, KPENTER (keypad)
1. Hotkey support for joy0/joy1 swap (**CTRL+any SHIFT+UNDO**), joy0 keyboard mapping (**CTRL+LSHIFT+HELP**) and joy1 keyboard mapping (**CTRL+RSHIFT+HELP**) ... so you can anytime swap joysticks, disable the mapping (for instance when you want to type your name) etc. I've decided not to swap keyboard mappings with joy0/joy1 as this introduces more chaos than good -- what to do if one of the mappings is off, what to do if we're in joystick mouse mode and so on...
1. CE_CONF disables joystick keyboard mapping -- especially important now, if you map UP/DOWN arrows as joystick movements
1. Improved navigation in CE_CONF -- **TAB** jumps to the first button and then goes forwards, **SHIFT+TAB** jumps to the last button and then goes backwards
1. Improved handling of linux scan codes, should definitely fix #119 
1. UNDO is equivalent to ESC = back to previous screen
1. Joystick fixes in mouse event reporting mode
1. Fixed enabling joystick event reporting for many commands (and vice versa, enabling mouse event reporting for mouse commands)

Some cleanup, some new bugs ;), you know the deal. I've tested it as much as humanly possible but only with a couple of games and own "unit tests" (Hi @atarijookie ! ;-))

Please merge (not squash) it.