### PR TITLE
Ikbd passthrough

### DIFF
--- a/ce_franz_fw/init.c
+++ b/ce_franz_fw/init.c
@@ -350,7 +350,7 @@ void initUsarts(void)
     usartStruct.USART_Mode                  = USART_Mode_Rx | USART_Mode_Tx;
     usartStruct.USART_HardwareFlowControl   = USART_HardwareFlowControl_None;
     
-    USART_Init(USART1, &usartStruct);               // Configure USART1 - 9600 baud -- for communication with RPi
+    USART_Init(USART1, &usartStruct);               // Configure USART1 - 19200 baud -- for communication with RPi
 
     usartStruct.USART_BaudRate              = 7812;   
     USART_Init(USART2, &usartStruct);               // Configure USART2 - 7812 baud  -- for communication with ST

--- a/ce_franz_fw/main.h
+++ b/ce_franz_fw/main.h
@@ -21,9 +21,9 @@ BYTE timeout(void);
 #define ATN_SYNC_WORD						0xcafe
 
 // commands sent from device to host
-#define ATN_FW_VERSION					0x01							// followed by string with FW version (length: 4 WORDs - cmd, v[0], v[1], 0)
-#define ATN_SECTOR_WRITTEN      0x03               	                    // sent: 3, side (highest bit) + track #, current sector #
-#define ATN_SEND_TRACK          0x04            		                // send the whole track
+#define ATN_FW_VERSION          0x01        // followed by string with FW version (length: 4 WORDs - cmd, v[0], v[1], 0)
+#define ATN_SECTOR_WRITTEN      0x03        // sent: 3, side (highest bit) + track #, current sector #
+#define ATN_SEND_TRACK          0x04        // send the whole track
 
 // commands sent from host to device
 #define CMD_WRITE_PROTECT_OFF			0x10


### PR DESCRIPTION
- changes done only in Franz 
- adds check if the RPi is up or down (receiving FW info or not)
- depending on that sends IKBD stream to RPI, or directly to ST
- to do this pass through, you need Franz in running state (not reset), so you either have to replace reset pull down with some reset chip, or add simple pre-init linux app which will pull the reset up
